### PR TITLE
Fix constant f-string usages

### DIFF
--- a/Tools.py
+++ b/Tools.py
@@ -25,7 +25,7 @@ def parse_target_date(target_date: str | None) -> datetime.datetime | None:
             # Try date-only format (YYYY-MM-DD)
             return datetime.datetime.strptime(target_date, "%Y-%m-%d")
         except ValueError:
-            raise ValueError(f"Invalid target_date format. Use ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)")
+            raise ValueError("Invalid target_date format. Use ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)")
 
 def validate_memory_type(memory_type: str, field_name: str = "memory_type") -> None:
     """Validate memory type is one of the allowed values."""

--- a/app.py
+++ b/app.py
@@ -179,7 +179,7 @@ def prepare_messages_with_thinking(system_prompt, user_message, ollama_client):
                 # Recent messages: include full thinking
                 print(f"[THINKING] Including full thinking for recent message (age {age})")
                 full_content = f"<think>\n{thinking}\n</think>\n{content}"
-                print(f"[THINKING CONTEXT] Message with full thinking being sent to model:")
+                print("[THINKING CONTEXT] Message with full thinking being sent to model:")
                 print(f"{'='*50}")
                 print(full_content)
                 print(f"{'='*50}\n")
@@ -197,7 +197,7 @@ def prepare_messages_with_thinking(system_prompt, user_message, ollama_client):
                 summarized = prepare_messages_with_thinking._thinking_cache[cache_key]
                 if summarized:
                     full_content = f"<think>\n{summarized}\n</think>\n{content}"
-                    print(f"[THINKING CONTEXT] Message with summarized thinking being sent to model:")
+                    print("[THINKING CONTEXT] Message with summarized thinking being sent to model:")
                     print(f"{'='*50}")
                     print(full_content)
                     print(f"{'='*50}\n")
@@ -443,7 +443,7 @@ def chat_endpoint():
                     
                     # Print tool results
                     if tool_outputs:
-                        print(f"\n[TOOL RESULTS] Tool execution results:")
+                        print("\n[TOOL RESULTS] Tool execution results:")
                         print(f"{'='*50}")
                         for i, output in enumerate(tool_outputs):
                             tool_call_id = output.get('tool_call_id', 'unknown')
@@ -520,7 +520,7 @@ The current time is: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
                         # Print full streaming response when done
                         if streaming_response:
                             print(f"\n{'='*60}")
-                            print(f"[MODEL RESPONSE] Full streaming response:")
+                            print("[MODEL RESPONSE] Full streaming response:")
                             print(f"{'='*60}")
                             print(streaming_response)
                             print(f"{'='*60}\n")
@@ -671,7 +671,7 @@ if __name__ == '__main__':
         requests.get(config.OLLAMA_BASE_URL, timeout=2)
         print(f"[INFO] Ollama connected at {config.OLLAMA_BASE_URL}")
     except:
-        logging.warning(f"Could not connect to Ollama")
+        logging.warning("Could not connect to Ollama")
     
     # Initialize TTS
     initialize_tts()

--- a/stt_service.py
+++ b/stt_service.py
@@ -252,7 +252,7 @@ class STTService:
                                         # print(f"[DEBUG] Sending acknowledgment: '{response}'")
                                         
                                         # === TERMINAL LOGGING FOR WAKE WORD ===
-                                        print_transcription_to_terminal(f"WAKE WORD DETECTED -> Activating F.R.E.D. (Silent Mode)", "WAKE WORD")
+                                        print_transcription_to_terminal("WAKE WORD DETECTED -> Activating F.R.E.D. (Silent Mode)", "WAKE WORD")
                                         
                                         # REMOVED: Acknowledgment callback
                                         # if self.transcription_callback:
@@ -262,7 +262,7 @@ class STTService:
                                         self.is_listening = True
                                         self.speech_buffer = []
                                         self.last_speech_time = time.time()
-                                        print(f"[DEBUG] Now listening for commands silently. Buffer cleared.")
+                                        print("[DEBUG] Now listening for commands silently. Buffer cleared.")
                                         continue
 
                                 # Process speech while listening - EXACT same logic as old system
@@ -273,13 +273,13 @@ class STTService:
                                         print(f"\n[{datetime.now().strftime('%H:%M:%S')}] Stop word detected. Going to sleep.")
                                         
                                         # === TERMINAL LOGGING FOR STOP WORD ===
-                                        print_transcription_to_terminal(f"STOP WORD DETECTED -> Deactivating F.R.E.D.", "STOP WORD")
+                                        print_transcription_to_terminal("STOP WORD DETECTED -> Deactivating F.R.E.D.", "STOP WORD")
                                         
                                         if self.transcription_callback:
                                             self.transcription_callback("goodbye")
                                         self.is_listening = False
                                         self.speech_buffer = []
-                                        print(f"[DEBUG] Stopped listening. Buffer cleared.")
+                                        print("[DEBUG] Stopped listening. Buffer cleared.")
                                         continue
                                     
                                     # Add speech to buffer if it's not too short - EXACT same logic
@@ -314,18 +314,18 @@ class STTService:
                         
                         # Temporarily stop listening while processing - EXACT same as old system
                         self.is_listening = False
-                        print(f"[DEBUG] Temporarily stopped listening for processing")
+                        print("[DEBUG] Temporarily stopped listening for processing")
                         
                         try:
                             if self.transcription_callback:
-                                print(f"\nProcessing message through callback...")  # EXACT same as old system
+                                print("\nProcessing message through callback...")  # EXACT same as old system
                                 print(f"[DEBUG] Sending complete utterance to callback: '{complete_utterance}'")
                                 self.transcription_callback(complete_utterance)
                             
                             # Resume listening after response - EXACT same as old system
                             self.is_listening = True
                             print("\nListening for next input...")  # EXACT same as old system
-                            print(f"[DEBUG] Resumed listening after processing")
+                            print("[DEBUG] Resumed listening after processing")
                         except Exception as e:
                             print(f"\nError in callback processing: {str(e)}")  # EXACT same error message
                             logger.error(f"Error in callback processing: {str(e)}")


### PR DESCRIPTION
## Summary
- clean up unused f-strings in logging and debug output
- keep behaviour while removing unnecessary formatting

## Testing
- `python -m py_compile Tools.py app.py config.py memory/librarian.py scripts/generate_fake_memories.py short_term_memory.py stt_service.py`
- `pyflakes Tools.py app.py config.py memory/librarian.py scripts/generate_fake_memories.py short_term_memory.py stt_service.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6840b3d8d7688320b099cf9efbc2c5e9