### PR TITLE
Make STM retrieval threshold configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,6 +64,7 @@ class Config:
     STM_MAX_MEMORIES = 100                      # total capacity
     STM_SIMILARITY_THRESHOLD = 0.85             # deduplication threshold
     STM_RETRIEVAL_LIMIT = 2                     # results per query
+    STM_RETRIEVAL_THRESHOLD = 0.3               # similarity threshold for context retrieval
     STM_ANALYSIS_MODEL = "hf.co/unsloth/Qwen3-4B-GGUF:Q4_K_M"  # configurable model for analysis
     
     # Wake Words and Commands

--- a/short_term_memory.py
+++ b/short_term_memory.py
@@ -200,7 +200,7 @@ def query_stm_context(user_message: str) -> str:
                 embedding = np.frombuffer(embedding_blob, dtype=np.float32)
                 
                 similarity = cosine_similarity([query_embedding], [embedding])[0][0]
-                if similarity > 0.3:  # Lower threshold for context retrieval
+                if similarity > config.STM_RETRIEVAL_THRESHOLD:
                     relevant_memories.append((content, created_at, similarity))
         
         if not relevant_memories:


### PR DESCRIPTION
## Summary
- add a configuration value for STM retrieval similarity threshold
- use the configurable threshold when retrieving STM memories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b3d8f1588320896e5fe9758c1656