### PR TITLE
Refactor logging to use olliePrint

### DIFF
--- a/check_tunnel.py
+++ b/check_tunnel.py
@@ -5,13 +5,14 @@ Quick tunnel status checker for F.R.E.D.
 import json
 import os
 from ollietec_theme import apply_theme
+from ollie_print import olliePrint
 
 apply_theme()
 
 def check_tunnel_status():
     """Check and display current tunnel status"""
     
-    print("[NETWORK] Checking F.R.E.D. tunnel status...")
+    olliePrint("[NETWORK] Checking F.R.E.D. tunnel status...")
     
     # Check tunnel_info.json
     if os.path.exists('tunnel_info.json'):
@@ -21,32 +22,32 @@ def check_tunnel_status():
                 tunnel_url = tunnel_data.get('webrtc_server')
                 
                 if tunnel_url:
-                    print("\n" + "="*80)
-                    print("🌐 ACTIVE NGROK TUNNEL FOUND:")
-                    print("="*80)
-                    print(f"📡 URL: {tunnel_url}")
-                    print(f"📱 Pi Command: python client.py --server {tunnel_url}")
-                    print("="*80)
+                    olliePrint("\n" + "="*80)
+                    olliePrint("🌐 ACTIVE NGROK TUNNEL FOUND:")
+                    olliePrint("="*80)
+                    olliePrint(f"📡 URL: {tunnel_url}")
+                    olliePrint(f"📱 Pi Command: python client.py --server {tunnel_url}")
+                    olliePrint("="*80)
                     
                     # Test if tunnel is reachable
                     try:
                         import requests
                         response = requests.get(tunnel_url, timeout=5)
                         if response.status_code == 200:
-                            print("[SUCCESS] Tunnel is ACTIVE and reachable!")
+                            olliePrint("[SUCCESS] Tunnel is ACTIVE and reachable!")
                         else:
-                            print(f"[WARNING] Tunnel responds but may have issues (Status: {response.status_code})")
+                            olliePrint(f"[WARNING] Tunnel responds but may have issues (Status: {response.status_code})")
                     except Exception as e:
-                        print(f"[ERROR] Tunnel may be down (Error: {e})")
+                        olliePrint(f"[ERROR] Tunnel may be down (Error: {e})")
                         
                 else:
-                    print("[ERROR] No tunnel URL found in tunnel_info.json")
+                    olliePrint("[ERROR] No tunnel URL found in tunnel_info.json")
                     
         except Exception as e:
-            print(f"[ERROR] Error reading tunnel_info.json: {e}")
+            olliePrint(f"[ERROR] Error reading tunnel_info.json: {e}")
     else:
-        print("[ERROR] No tunnel_info.json found")
-        print("[INFO] Start F.R.E.D. with: python start_fred_with_webrtc.py")
+        olliePrint("[ERROR] No tunnel_info.json found")
+        olliePrint("[INFO] Start F.R.E.D. with: python start_fred_with_webrtc.py")
     
     # Check if ngrok is running
     try:
@@ -54,14 +55,14 @@ def check_tunnel_status():
         response = requests.get("http://localhost:4040/api/tunnels", timeout=2)
         tunnels = response.json()
         
-        print(f"\n🔧 Ngrok API Status: {len(tunnels.get('tunnels', []))} tunnel(s) running")
+        olliePrint(f"\n🔧 Ngrok API Status: {len(tunnels.get('tunnels', []))} tunnel(s) running")
         for tunnel in tunnels.get('tunnels', []):
             public_url = tunnel.get('public_url', 'Unknown')
             local_addr = tunnel.get('config', {}).get('addr', 'Unknown')
-            print(f"   📡 {public_url} → {local_addr}")
+            olliePrint(f"   📡 {public_url} → {local_addr}")
             
     except Exception:
-        print("\n🔧 Ngrok API: Not accessible (ngrok may not be running)")
+        olliePrint("\n🔧 Ngrok API: Not accessible (ngrok may not be running)")
 
 if __name__ == "__main__":
     check_tunnel_status() 

--- a/debug_datachannel.py
+++ b/debug_datachannel.py
@@ -7,11 +7,12 @@ Tests if aiortc data channels work between client and server
 import asyncio
 import json
 from aiortc import RTCPeerConnection, RTCSessionDescription
+from ollie_print import olliePrint
 
 async def test_datachannel():
     """Test data channel between two peer connections"""
     
-    print("🧪 [TEST] Starting data channel test...")
+    olliePrint("🧪 [TEST] Starting data channel test...")
     
     # Create two peer connections (simulating client and server)
     pc1 = RTCPeerConnection()
@@ -23,100 +24,100 @@ async def test_datachannel():
     
     # Client side (pc1) creates data channel
     dc1 = pc1.createDataChannel('test', ordered=True)
-    print(f"🔧 [PC1] Data channel created: {dc1.label}, state: {dc1.readyState}")
+    olliePrint(f"🔧 [PC1] Data channel created: {dc1.label}, state: {dc1.readyState}")
     
     @dc1.on('open')
     def on_dc1_open():
         nonlocal dc1_opened
         dc1_opened = True
-        print("✅ [PC1] Data channel opened!")
+        olliePrint("✅ [PC1] Data channel opened!")
         dc1.send("Hello from PC1")
     
     @dc1.on('message')
     def on_dc1_message(message):
-        print(f"📨 [PC1] Received: {message}")
+        olliePrint(f"📨 [PC1] Received: {message}")
     
     # Server side (pc2) handles incoming data channel
     @pc2.on('datachannel')
     def on_datachannel(channel):
         nonlocal dc2_opened
-        print(f"🔧 [PC2] Data channel received: {channel.label}, state: {channel.readyState}")
+        olliePrint(f"🔧 [PC2] Data channel received: {channel.label}, state: {channel.readyState}")
         
         @channel.on('open')
         def on_dc2_open():
             nonlocal dc2_opened
             dc2_opened = True
-            print("✅ [PC2] Data channel opened!")
+            olliePrint("✅ [PC2] Data channel opened!")
             channel.send("Hello from PC2")
         
         @channel.on('message')
         def on_dc2_message(message):
-            print(f"📨 [PC2] Received: {message}")
+            olliePrint(f"📨 [PC2] Received: {message}")
     
     # Connection state monitoring
     @pc1.on('connectionstatechange')
     async def on_pc1_state():
-        print(f"🔗 [PC1] Connection: {pc1.connectionState}")
+        olliePrint(f"🔗 [PC1] Connection: {pc1.connectionState}")
     
     @pc2.on('connectionstatechange') 
     async def on_pc2_state():
-        print(f"🔗 [PC2] Connection: {pc2.connectionState}")
+        olliePrint(f"🔗 [PC2] Connection: {pc2.connectionState}")
     
     @pc1.on('iceconnectionstatechange')
     async def on_pc1_ice():
-        print(f"🧊 [PC1] ICE: {pc1.iceConnectionState}")
+        olliePrint(f"🧊 [PC1] ICE: {pc1.iceConnectionState}")
     
     @pc2.on('iceconnectionstatechange')
     async def on_pc2_ice():
-        print(f"🧊 [PC2] ICE: {pc2.iceConnectionState}")
+        olliePrint(f"🧊 [PC2] ICE: {pc2.iceConnectionState}")
     
     try:
         # Create offer
-        print("📤 [PC1] Creating offer...")
+        olliePrint("📤 [PC1] Creating offer...")
         offer = await pc1.createOffer()
         await pc1.setLocalDescription(offer)
         
         # Set remote description on server
-        print("📥 [PC2] Setting remote description...")
+        olliePrint("📥 [PC2] Setting remote description...")
         await pc2.setRemoteDescription(RTCSessionDescription(
             sdp=offer.sdp, type=offer.type
         ))
         
         # Create answer
-        print("📤 [PC2] Creating answer...")
+        olliePrint("📤 [PC2] Creating answer...")
         answer = await pc2.createAnswer()
         await pc2.setLocalDescription(answer)
         
         # Set remote description on client
-        print("📥 [PC1] Setting remote description...")
+        olliePrint("📥 [PC1] Setting remote description...")
         await pc1.setRemoteDescription(RTCSessionDescription(
             sdp=answer.sdp, type=answer.type
         ))
         
-        print("⏰ [TEST] Waiting for connections...")
+        olliePrint("⏰ [TEST] Waiting for connections...")
         
         # Wait for connections to establish
         for i in range(30):  # 30 second timeout
             await asyncio.sleep(1)
             
-            print(f"⏱️  [{i+1}s] PC1: {pc1.connectionState}/{pc1.iceConnectionState}, "
+            olliePrint(f"⏱️  [{i+1}s] PC1: {pc1.connectionState}/{pc1.iceConnectionState}, "
                   f"PC2: {pc2.connectionState}/{pc2.iceConnectionState}")
-            print(f"     DC1: {dc1.readyState}, DC2 opened: {dc2_opened}")
+            olliePrint(f"     DC1: {dc1.readyState}, DC2 opened: {dc2_opened}")
             
             if dc1_opened and dc2_opened:
-                print("🎉 [SUCCESS] Both data channels opened!")
+                olliePrint("🎉 [SUCCESS] Both data channels opened!")
                 break
                 
             if pc1.connectionState == "failed" or pc2.connectionState == "failed":
-                print("❌ [FAILED] Connection failed")
+                olliePrint("❌ [FAILED] Connection failed")
                 break
         else:
-            print("⏰ [TIMEOUT] Data channels did not open within 30 seconds")
+            olliePrint("⏰ [TIMEOUT] Data channels did not open within 30 seconds")
     
     finally:
         await pc1.close()
         await pc2.close()
-        print("🧹 [CLEANUP] Connections closed")
+        olliePrint("🧹 [CLEANUP] Connections closed")
 
 if __name__ == "__main__":
     asyncio.run(test_datachannel()) 

--- a/memory/librarian.py
+++ b/memory/librarian.py
@@ -7,6 +7,7 @@ import time
 import os # For potential environment variables later
 import logging
 import threading
+from ollie_print import olliePrint
 from contextlib import contextmanager
 
 # --- Configuration ---
@@ -1200,11 +1201,11 @@ def clear_all_memory(force=False):
 try:
     import duckdb
     if __name__ == "__main__":
-        print("Librarian script loaded. Initializing database...")
+        olliePrint("Librarian script loaded. Initializing database...")
         init_db()
-        print("Database ready.")
+        olliePrint("Database ready.")
         # Add test calls here if desired, wrapped in try/except ImportError
 except ImportError:
     logging.warning("DuckDB not found during import. Database functionality is disabled.")
     if __name__ == "__main__":
-        print("Librarian script loaded, but DuckDB is missing. Database functionality disabled.")
+        olliePrint("Librarian script loaded, but DuckDB is missing. Database functionality disabled.")

--- a/ollie_print.py
+++ b/ollie_print.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from datetime import datetime
+
+COLOR_CODES = {
+    'info': '\033[34m',  # blue
+    'success': '\033[32m',
+    'warning': '\033[33m',
+    'error': '\033[31m'
+}
+RESET = '\033[0m'
+COMMENTS = {
+    'info': 'Systems green across the board.',
+    'success': 'Mission accomplished!',
+    'warning': 'Caution: power conduit unstable.',
+    'error': 'Critical failure detected!'
+}
+
+def olliePrint(message, level='info', module=None):
+    """Print a colorized FRED-style message with banner."""
+    level = level.lower()
+    color = COLOR_CODES.get(level, COLOR_CODES['info'])
+    if not sys.stdout.isatty():
+        color = ''
+    banner_module = module or os.path.splitext(os.path.basename(sys._getframe(1).f_code.co_filename))[0]
+    timestamp = datetime.now().strftime('%H:%M:%S')
+    header = f"{banner_module} [{timestamp}] - Designed by Ollie-Tec"
+    bar = '-' * len(header)
+    msg = f"{color}{message}{RESET if sys.stdout.isatty() else ''}"
+    print(f"{bar}\n{header}\n{bar}\n{msg} {COMMENTS.get(level, '')}")

--- a/pi_client/fred_pi_client.py
+++ b/pi_client/fred_pi_client.py
@@ -34,6 +34,7 @@ import vosk
 
 # Import Ollie-Tec theming
 from ollietec_theme import apply_theme, banner
+from ollie_print import olliePrint
 
 # WebRTC imports
 from aiortc import RTCPeerConnection, RTCSessionDescription, RTCConfiguration, RTCIceServer
@@ -91,8 +92,8 @@ class FREDPiSTTService:
             return True
             
         try:
-            print("[ARMLINK STT] Initializing voice recognition systems...")
-            print("🔧 Loading Vosk small English model...")
+            olliePrint("[ARMLINK STT] Initializing voice recognition systems...")
+            olliePrint("🔧 Loading Vosk small English model...")
             
             # Set Vosk log level to reduce noise
             vosk.SetLogLevel(-1)
@@ -112,25 +113,25 @@ class FREDPiSTTService:
                     break
             
             if not model_path:
-                print("❌ [CRITICAL] Vosk model not found!")
-                print("💡 [SOLUTION] Run: bash install_vosk_model.sh")
+                olliePrint("❌ [CRITICAL] Vosk model not found!")
+                olliePrint("💡 [SOLUTION] Run: bash install_vosk_model.sh")
                 return False
             
             # Initialize Vosk model
             self.model = vosk.Model(model_path)
             self.recognizer = vosk.KaldiRecognizer(self.model, self.sample_rate)
             
-            print("✅ [ARMLINK STT] Voice recognition ONLINE")
-            print(f"📊 Model: Vosk small English (optimized for Pi)")
-            print(f"📍 Path: {model_path}")
+            olliePrint("✅ [ARMLINK STT] Voice recognition ONLINE")
+            olliePrint(f"📊 Model: Vosk small English (optimized for Pi)")
+            olliePrint(f"📍 Path: {model_path}")
             
             self.is_initialized = True
             return True
             
         except Exception as e:
-            logger.error(f"[CRITICAL] STT initialization failed: {e}")
-            print(f"❌ [ARMLINK STT] Voice recognition FAILED: {e}")
-            print("💡 [SOLUTION] Run: bash install_vosk_model.sh")
+            olliePrint(f"[CRITICAL] STT initialization failed: {e}")
+            olliePrint(f"❌ [ARMLINK STT] Voice recognition FAILED: {e}")
+            olliePrint("💡 [SOLUTION] Run: bash install_vosk_model.sh")
             return False
 
     def start_processing(self, callback: Callable):
@@ -139,7 +140,7 @@ class FREDPiSTTService:
             if not self.initialize():
                 return False
                 
-        print("🎤 [ARMLINK STT] Starting audio processing...")
+        olliePrint("🎤 [ARMLINK STT] Starting audio processing...")
         self.transcription_callback = callback
         self.is_processing = True
         
@@ -150,7 +151,7 @@ class FREDPiSTTService:
         )
         self.processing_thread.start()
         
-        print("👂 [ARMLINK STT] Listening for wake word...")
+        olliePrint("👂 [ARMLINK STT] Listening for wake word...")
         return True
     
     def stop_processing(self):
@@ -158,13 +159,13 @@ class FREDPiSTTService:
         self.is_processing = False
         if self.processing_thread:
             self.processing_thread.join(timeout=2.0)
-        print("🔇 [ARMLINK STT] Voice recognition offline")
+        olliePrint("🔇 [ARMLINK STT] Voice recognition offline")
     
     def _audio_capture_loop(self):
         """Audio capture and processing loop using sounddevice"""
         try:
             import sounddevice as sd
-            print("🎤 [AUDIO] Starting audio capture...")
+            olliePrint("🎤 [AUDIO] Starting audio capture...")
             
             def audio_callback(indata, frames, time, status):
                 if self.is_processing:
@@ -181,7 +182,7 @@ class FREDPiSTTService:
                 callback=audio_callback,
                 dtype=np.float32
             ):
-                print("✅ [AUDIO] Audio capture ONLINE")
+                olliePrint("✅ [AUDIO] Audio capture ONLINE")
                 
                 while self.is_processing:
                     try:
@@ -191,13 +192,13 @@ class FREDPiSTTService:
                         else:
                             time.sleep(0.01)
                     except Exception as e:
-                        logger.error(f"Audio processing error: {e}")
+                        olliePrint(f"Audio processing error: {e}")
                         time.sleep(0.1)
                         
         except ImportError:
-            print("❌ [AUDIO] sounddevice not available")
+            olliePrint("❌ [AUDIO] sounddevice not available")
         except Exception as e:
-            print(f"❌ [AUDIO] Audio capture failed: {e}")
+            olliePrint(f"❌ [AUDIO] Audio capture failed: {e}")
     
     def _process_audio_chunk(self, audio_chunk: np.ndarray):
         """Process individual audio chunk"""
@@ -218,7 +219,7 @@ class FREDPiSTTService:
                 self._handle_transcribed_text(text.strip().lower())
                 
         except Exception as e:
-            logger.error(f"Audio chunk processing error: {e}")
+            olliePrint(f"Audio chunk processing error: {e}")
     
     def _transcribe_audio(self, audio_chunk: np.ndarray) -> str:
         """Transcribe audio using Vosk"""
@@ -250,22 +251,22 @@ class FREDPiSTTService:
             if self._transcription_count % 100 == 0:
                 elapsed = time.time() - self._start_time
                 avg_time = elapsed / self._transcription_count
-                print(f"📊 [PERFORMANCE] {self._transcription_count} transcriptions, avg: {avg_time:.3f}s")
+                olliePrint(f"📊 [PERFORMANCE] {self._transcription_count} transcriptions, avg: {avg_time:.3f}s")
             
             return text.strip()
             
         except Exception as e:
-            logger.error(f"Transcription error: {e}")
+            olliePrint(f"Transcription error: {e}")
             return ""
     
     def _handle_transcribed_text(self, text: str):
         """Handle transcribed text with wake word detection"""
-        print(f"🎙️ [DETECTED] '{text}'")
+        olliePrint(f"🎙️ [DETECTED] '{text}'")
         
         # Check for wake words when not listening
         if not self.is_listening:
             if any(wake_word in text for wake_word in self.wake_words):
-                print(f"👋 [WAKE] Wake word detected! Listening...")
+                olliePrint(f"👋 [WAKE] Wake word detected! Listening...")
                 self.is_listening = True
                 self.speech_buffer = []
                 self.last_speech_time = time.time()
@@ -275,7 +276,7 @@ class FREDPiSTTService:
         if self.is_listening:
             # Check for stop words
             if any(stop_word in text for stop_word in self.stop_words):
-                print(f"💤 [SLEEP] Stop word detected")
+                olliePrint(f"💤 [SLEEP] Stop word detected")
                 if self.transcription_callback:
                     self.transcription_callback("goodbye")
                 self.is_listening = False
@@ -284,7 +285,7 @@ class FREDPiSTTService:
             
             # Add to speech buffer if meaningful
             if len(text.split()) > 1:  # More than one word
-                print(f"📝 [BUFFER] Adding: '{text}'")
+                olliePrint(f"📝 [BUFFER] Adding: '{text}'")
                 self.last_speech_time = time.time()
                 self.speech_buffer.append(text)
     
@@ -294,7 +295,7 @@ class FREDPiSTTService:
             return
             
         complete_text = " ".join(self.speech_buffer)
-        print(f"🗣️ [COMPLETE] Processing: '{complete_text}'")
+        olliePrint(f"🗣️ [COMPLETE] Processing: '{complete_text}'")
         
         # Clear buffer
         self.speech_buffer = []
@@ -304,7 +305,7 @@ class FREDPiSTTService:
             self.transcription_callback(complete_text)
         
         # Resume listening
-        print("👂 [READY] Listening for next command...")
+        olliePrint("👂 [READY] Listening for next command...")
 
 
 class FREDPiClient:
@@ -325,8 +326,8 @@ class FREDPiClient:
         
     async def start(self):
         """Start the F.R.E.D. Pi client"""
-        print(banner("F.R.E.D. Pi Glasses v2.0"))
-        print("[SHELTER-CORE] Booting field AI interface...")
+        olliePrint(banner("F.R.E.D. Pi Glasses v2.0"))
+        olliePrint("[SHELTER-CORE] Booting field AI interface...")
         
         # Store the event loop for thread-safe operations
         self.loop = asyncio.get_running_loop()
@@ -336,15 +337,15 @@ class FREDPiClient:
         
         # Start STT service
         if not self.stt_service.start_processing(self._handle_transcription):
-            print("❌ [CRITICAL] STT initialization failed")
+            olliePrint("❌ [CRITICAL] STT initialization failed")
             return False
         
         # Setup WebRTC connection
         await self._setup_webrtc()
         
         self.is_running = True
-        print("[SHELTER-NET] F.R.E.D. Pi Glasses ONLINE!")
-        print("[ARMLINK] Ready for wasteland operations...")
+        olliePrint("[SHELTER-NET] F.R.E.D. Pi Glasses ONLINE!")
+        olliePrint("[ARMLINK] Ready for wasteland operations...")
         
         # Main loop
         await self._run_main_loop()
@@ -352,7 +353,7 @@ class FREDPiClient:
     async def _init_camera(self):
         """Initialize Picamera2 for vision"""
         try:
-            print("📸 [VISION] Initializing ArmLink camera systems...")
+            olliePrint("📸 [VISION] Initializing ArmLink camera systems...")
             from picamera2 import Picamera2
             
             self.camera = Picamera2()
@@ -361,7 +362,7 @@ class FREDPiClient:
             sensor_modes = self.camera.sensor_modes
             max_mode = max(sensor_modes, key=lambda x: x['size'][0] * x['size'][1])
             max_res = max_mode['size']
-            print(f"🎯 [VISION] Using native resolution {max_res}")
+            olliePrint(f"🎯 [VISION] Using native resolution {max_res}")
             
             config = self.camera.create_video_configuration(
                 main={"size": max_res, "format": "RGB888"},
@@ -376,10 +377,10 @@ class FREDPiClient:
             
             self.camera.configure(config)
             self.camera.start()
-            print("✅ [VISION] Camera systems ONLINE")
+            olliePrint("✅ [VISION] Camera systems ONLINE")
             
         except Exception as e:
-            print(f"❌ [VISION] Camera initialization failed: {e}")
+            olliePrint(f"❌ [VISION] Camera initialization failed: {e}")
             self.camera = None
 
     def create_local_tracks(self, video=True):
@@ -387,7 +388,7 @@ class FREDPiClient:
         tracks = []
         
         if video and self.camera:
-            print("🎥 Setting up video with Picamera2...")
+            olliePrint("🎥 Setting up video with Picamera2...")
             try:
                 from aiortc import VideoStreamTrack
                 import av
@@ -399,7 +400,7 @@ class FREDPiClient:
                         self.camera = camera
                         self.frame_count = 0
                         self.start_time = time.time()
-                        print("✅ Picamera2 video track initialized")
+                        olliePrint("✅ Picamera2 video track initialized")
 
                     async def recv(self):
                         """Receive video frames from the camera"""
@@ -408,7 +409,7 @@ class FREDPiClient:
                         try:
                             array = self.camera.capture_array("main")
                         except Exception as e:
-                            print(f"💥 Failed to capture frame from Picamera2: {e}")
+                            olliePrint(f"💥 Failed to capture frame from Picamera2: {e}")
                             # Fallback black frame
                             array = np.zeros((2464, 3280, 3), dtype=np.uint8)
                         
@@ -419,27 +420,27 @@ class FREDPiClient:
 
                         self.frame_count += 1
                         if self.frame_count == 1:
-                            print(f"🚀 First frame sent! Size: {array.shape}")
+                            olliePrint(f"🚀 First frame sent! Size: {array.shape}")
                         elif self.frame_count % 150 == 0:
                             elapsed = time.time() - self.start_time
                             if elapsed > 0:
                                 fps = self.frame_count / elapsed
-                                print(f"📊 Sent {self.frame_count} frames. Average FPS: {fps:.2f}")
+                                olliePrint(f"📊 Sent {self.frame_count} frames. Average FPS: {fps:.2f}")
 
                         return frame
 
                 tracks.append(PiCamera2Track(self.camera))
-                print("✅ Picamera2 video track created successfully!")
+                olliePrint("✅ Picamera2 video track created successfully!")
                 
             except Exception as e:
-                print(f"❌ Video track creation failed: {e}")
+                olliePrint(f"❌ Video track creation failed: {e}")
         
         return tracks
 
     async def _setup_webrtc(self):
         """Setup WebRTC connection to F.R.E.D. server"""
         try:
-            print("🔗 [WEBRTC] Establishing secure link to F.R.E.D. mainframe...")
+            olliePrint("🔗 [WEBRTC] Establishing secure link to F.R.E.D. mainframe...")
             
             # Configure ICE servers
             try:
@@ -450,7 +451,7 @@ class FREDPiClient:
                 config = RTCConfiguration(iceServers=ice_servers)
                 self.pc = RTCPeerConnection(configuration=config)
             except Exception:
-                print("🔧 Using legacy WebRTC configuration")
+                olliePrint("🔧 Using legacy WebRTC configuration")
                 self.pc = RTCPeerConnection()
             
             # Set up data channel for communication
@@ -458,8 +459,8 @@ class FREDPiClient:
             
             @self.data_channel.on('open')
             def on_open():
-                print('[SHELTER-NET] Secure connection established with F.R.E.D. mainframe!')
-                print('[ARMLINK] Audio/visual sensors ONLINE - ready for wasteland operations...')
+                olliePrint('[SHELTER-NET] Secure connection established with F.R.E.D. mainframe!')
+                olliePrint('[ARMLINK] Audio/visual sensors ONLINE - ready for wasteland operations...')
             
             @self.data_channel.on('message')
             def on_message(message):
@@ -468,7 +469,7 @@ class FREDPiClient:
                     pass
                 elif message.startswith('[ACK]'):
                     ack_text = message.replace('[ACK] ', '')
-                    print(f"[F.R.E.D.] {ack_text}")
+                    olliePrint(f"[F.R.E.D.] {ack_text}")
                 elif message.startswith('[AUDIO_BASE64:'):
                     # Handle incoming audio from F.R.E.D.
                     try:
@@ -476,39 +477,39 @@ class FREDPiClient:
                         format_info = message[14:header_end]
                         audio_b64 = message[header_end + 1:]
                         
-                        print(f"[TRANSMISSION] Incoming voice data from F.R.E.D. ({format_info})")
+                        olliePrint(f"[TRANSMISSION] Incoming voice data from F.R.E.D. ({format_info})")
                         self._play_audio_from_base64(audio_b64, format_info)
                         
                     except Exception as e:
-                        print(f"[ERROR] Audio processing failure: {e}")
+                        olliePrint(f"[ERROR] Audio processing failure: {e}")
                 else:
-                    print(f'\n[F.R.E.D.] {message}')
+                    olliePrint(f'\n[F.R.E.D.] {message}')
                 
                 if not message.startswith('[HEARTBEAT_ACK]'):
-                    print('[ARMLINK] Standing by for commands...')
+                    olliePrint('[ARMLINK] Standing by for commands...')
             
             @self.data_channel.on('close')
             def on_close():
-                print('[CRITICAL] Connection to F.R.E.D. mainframe terminated')
+                olliePrint('[CRITICAL] Connection to F.R.E.D. mainframe terminated')
                 raise Exception("Data channel closed")
             
             # Add video track. Audio is processed locally for STT and not streamed.
             tracks = self.create_local_tracks(video=True)
             
             if not tracks:
-                print("⚠️  No media tracks available - connecting with data channel only")
+                olliePrint("⚠️  No media tracks available - connecting with data channel only")
             
             for track in tracks:
                 self.pc.addTrack(track)
                 track_kind = getattr(track, 'kind', 'unknown')
                 track_type = type(track).__name__
-                print(f"📡 Added {track_kind} track ({track_type})")
+                olliePrint(f"📡 Added {track_kind} track ({track_type})")
             
             # Create offer and connect
             offer = await self.pc.createOffer()
             await self.pc.setLocalDescription(offer)
             
-            print(f"🔗 Connecting to {self.server_url}/offer...")
+            olliePrint(f"🔗 Connecting to {self.server_url}/offer...")
             
             headers = {
                 'Authorization': 'Bearer fred_pi_glasses_2024',
@@ -523,13 +524,13 @@ class FREDPiClient:
             if response.status_code == 200:
                 answer = RTCSessionDescription(**response.json())
                 await self.pc.setRemoteDescription(answer)
-                print("🚀 F.R.E.D. Pi Glasses connected and ready!")
+                olliePrint("🚀 F.R.E.D. Pi Glasses connected and ready!")
             else:
-                print(f"❌ Server error: {response.status_code}")
+                olliePrint(f"❌ Server error: {response.status_code}")
                 raise Exception(f"Server returned {response.status_code}")
                 
         except Exception as e:
-            print(f"❌ [WEBRTC] Connection failed: {e}")
+            olliePrint(f"❌ [WEBRTC] Connection failed: {e}")
             raise
     
     async def _run_main_loop(self):
@@ -549,22 +550,22 @@ class FREDPiClient:
                         self.data_channel.send('[HEARTBEAT]')
                         last_heartbeat = current_time
                         if int(current_time) % 120 == 0:  # Every 2 minutes
-                            print("[VITAL-MONITOR] ArmLink status confirmed")
+                            olliePrint("[VITAL-MONITOR] ArmLink status confirmed")
                     else:
                         raise Exception("Data channel not open")
                         
             except KeyboardInterrupt:
-                print("\n[SHUTDOWN] Field operative terminating connection")
+                olliePrint("\n[SHUTDOWN] Field operative terminating connection")
                 break
             except Exception as e:
-                print(f"[CRITICAL] Connection to mainframe lost: {e}")
+                olliePrint(f"[CRITICAL] Connection to mainframe lost: {e}")
                 break
         
         await self._cleanup()
     
     def _handle_transcription(self, text: str):
         """Handle transcribed speech from STT service"""
-        print(f"🎤 [COMMAND] '{text}'")
+        olliePrint(f"🎤 [COMMAND] '{text}'")
         
         # Send transcription via WebRTC data channel using thread-safe approach
         if self.data_channel and self.data_channel.readyState == 'open' and self.loop:
@@ -576,11 +577,11 @@ class FREDPiClient:
                 )
                 # Wait for completion with timeout
                 future.result(timeout=5.0)
-                print(f"📡 [TRANSMITTED] '{text}' sent to F.R.E.D. mainframe")
+                olliePrint(f"📡 [TRANSMITTED] '{text}' sent to F.R.E.D. mainframe")
             except Exception as e:
-                print(f"❌ [COMM] Transmission failed: {e}")
+                olliePrint(f"❌ [COMM] Transmission failed: {e}")
         else:
-            print("❌ [COMM] No data channel available")
+            olliePrint("❌ [COMM] No data channel available")
     
     async def _send_transcription_async(self, text: str):
         """Async helper to send transcription via data channel"""
@@ -594,7 +595,7 @@ class FREDPiClient:
         """Play audio from base64 data"""
         try:
             audio_data = base64.b64decode(audio_b64)
-            print(f"[AUDIO] F.R.E.D. transmission received ({len(audio_data)} bytes)")
+            olliePrint(f"[AUDIO] F.R.E.D. transmission received ({len(audio_data)} bytes)")
             
             with tempfile.NamedTemporaryFile(suffix=f'.{format_type}', delete=False) as temp_file:
                 temp_file.write(audio_data)
@@ -602,13 +603,13 @@ class FREDPiClient:
             
             try:
                 subprocess.run(['aplay', temp_file_path], check=True, capture_output=True)
-                print("[SUCCESS] F.R.E.D. voice transmission complete")
+                olliePrint("[SUCCESS] F.R.E.D. voice transmission complete")
             except subprocess.CalledProcessError:
                 try:
                     subprocess.run(['paplay', temp_file_path], check=True, capture_output=True)
-                    print("[SUCCESS] F.R.E.D. voice transmission complete (PulseAudio)")
+                    olliePrint("[SUCCESS] F.R.E.D. voice transmission complete (PulseAudio)")
                 except subprocess.CalledProcessError:
-                    print("[CRITICAL] Audio playback failed")
+                    olliePrint("[CRITICAL] Audio playback failed")
             
             try:
                 os.unlink(temp_file_path)
@@ -616,26 +617,26 @@ class FREDPiClient:
                 pass
                 
         except Exception as e:
-            print(f"[CRITICAL] Audio playback system failure: {e}")
+            olliePrint(f"[CRITICAL] Audio playback system failure: {e}")
     
     async def _cleanup(self):
         """Cleanup resources"""
-        print("[CLEANUP] Shutting down ArmLink systems...")
+        olliePrint("[CLEANUP] Shutting down ArmLink systems...")
         
         self.stt_service.stop_processing()
         
         if self.camera:
             try:
                 self.camera.stop()
-                print("📸 [VISION] Camera systems offline")
+                olliePrint("📸 [VISION] Camera systems offline")
             except Exception as e:
-                print(f"⚠️ [VISION] Camera cleanup error: {e}")
+                olliePrint(f"⚠️ [VISION] Camera cleanup error: {e}")
         
         if self.pc:
             await self.pc.close()
         
         self.is_running = False
-        print("[SHELTER-CORE] All systems offline. Stay safe out there!")
+        olliePrint("[SHELTER-CORE] All systems offline. Stay safe out there!")
 
 
 def get_server_url(provided_url=None):
@@ -643,10 +644,10 @@ def get_server_url(provided_url=None):
     if provided_url:
         if not provided_url.startswith(('http://', 'https://')):
             provided_url = f'http://{provided_url}'
-        print(f"🔗 Using provided F.R.E.D. server: {provided_url}")
+        olliePrint(f"🔗 Using provided F.R.E.D. server: {provided_url}")
         return provided_url
     
-    print("🔍 Auto-discovering F.R.E.D. mainframe...")
+    olliePrint("🔍 Auto-discovering F.R.E.D. mainframe...")
     
     # Try common local addresses
     local_addresses = [
@@ -660,7 +661,7 @@ def get_server_url(provided_url=None):
         try:
             response = requests.get(f'{url}/', timeout=2)
             if response.status_code == 200:
-                print(f"✅ Found F.R.E.D. mainframe at: {url}")
+                olliePrint(f"✅ Found F.R.E.D. mainframe at: {url}")
                 return url
         except:
             continue
@@ -671,16 +672,16 @@ def get_server_url(provided_url=None):
             tunnel_info = json.load(f)
             tunnel_url = tunnel_info.get('webrtc_server')
             if tunnel_url:
-                print(f"🌐 Found tunnel URL: {tunnel_url}")
+                olliePrint(f"🌐 Found tunnel URL: {tunnel_url}")
                 return tunnel_url
     except:
         pass
     
-    print("❌ [CRITICAL] No F.R.E.D. server found!")
-    print("\n[SHELTER-CORE] Troubleshooting protocols:")
-    print("1. Start F.R.E.D. WebRTC server: python start_fred_with_webrtc.py")
-    print("2. Use local URL: --server http://localhost:8080")
-    print("3. Use ngrok tunnel URL")
+    olliePrint("❌ [CRITICAL] No F.R.E.D. server found!")
+    olliePrint("\n[SHELTER-CORE] Troubleshooting protocols:")
+    olliePrint("1. Start F.R.E.D. WebRTC server: python start_fred_with_webrtc.py")
+    olliePrint("2. Use local URL: --server http://localhost:8080")
+    olliePrint("3. Use ngrok tunnel URL")
     
     raise Exception("❌ No F.R.E.D. server found. Please specify --server URL")
 
@@ -697,13 +698,13 @@ async def main():
         await client.start()
         
     except KeyboardInterrupt:
-        print("\n[SHUTDOWN] Field operative terminating connection")
+        olliePrint("\n[SHUTDOWN] Field operative terminating connection")
     except Exception as e:
-        print(f"\n[CRITICAL] System failure: {e}")
-        print("\n[SHELTER-CORE] Troubleshooting protocols:")
-        print("1. Verify F.R.E.D. mainframe is operational")
-        print("2. Check wasteland communication network")
-        print("3. Try manual server specification with --server")
+        olliePrint(f"\n[CRITICAL] System failure: {e}")
+        olliePrint("\n[SHELTER-CORE] Troubleshooting protocols:")
+        olliePrint("1. Verify F.R.E.D. mainframe is operational")
+        olliePrint("2. Check wasteland communication network")
+        olliePrint("3. Try manual server specification with --server")
         sys.exit(1)
 
 

--- a/scripts/generate_fake_memories.py
+++ b/scripts/generate_fake_memories.py
@@ -14,6 +14,7 @@ This script focuses on creating the memories that will orbit this conceptual cor
 import os
 import sys
 import datetime
+from ollie_print import olliePrint
 
 # Add the parent directory to sys.path to import librarian
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -25,18 +26,18 @@ import memory.librarian as lib
 DB_PATH = os.path.join(parent_dir, 'memory', 'memory.db')
 lib.DB_FILE = DB_PATH
 
-print(f"Setting memory database path to: {DB_PATH}")
+olliePrint(f"Setting memory database path to: {DB_PATH}")
 lib.init_db()
 
 # Clear existing memories
-print("Clearing existing memories...")
+olliePrint("Clearing existing memories...")
 if not lib.clear_all_memory(force=True): # Force clear for test data generation
-    print("CRITICAL: Failed to clear memory. Aborting fake memory generation.")
+    olliePrint("CRITICAL: Failed to clear memory. Aborting fake memory generation.")
     sys.exit(1)
 
 # Function to create specific memories and connections
 def generate_multi_level_test_graph():
-    print("Generating a multi-level deterministic test graph...")
+    olliePrint("Generating a multi-level deterministic test graph...")
     
     node_ids = {} # Use a dict to store nodes by name for clarity
 
@@ -77,14 +78,14 @@ def generate_multi_level_test_graph():
     for key, label, text, mem_type in node_data_to_create:
         try:
             node_ids[key] = lib.add_memory(label=label, text=text, memory_type=mem_type)
-            print(f"Created node '{label}' ({key}) with ID: {node_ids[key]}")
+            olliePrint(f"Created node '{label}' ({key}) with ID: {node_ids[key]}")
         except Exception as e:
-            print(f"ERROR creating node '{label}': {e}")
+            olliePrint(f"ERROR creating node '{label}': {e}")
             node_ids[key] = None # Ensure key exists but is None if creation failed
 
-    print("\n--- Created Memory Nodes ---")
+    olliePrint("\n--- Created Memory Nodes ---")
     success_count = sum(1 for nid in node_ids.values() if nid is not None)
-    print(f"Successfully created {success_count} out of {len(node_data_to_create)} memory nodes.")
+    olliePrint(f"Successfully created {success_count} out of {len(node_data_to_create)} memory nodes.")
 
     # --- Create Edges ---
     # Structure: Primary nodes have many connections, secondary fewer, tertiary fewest
@@ -135,7 +136,7 @@ def generate_multi_level_test_graph():
         ('Security_System', 'Morning_Routine', 'precedes')
     ]
 
-    print("\n--- Creating Edges Between Memory Nodes ---")
+    olliePrint("\n--- Creating Edges Between Memory Nodes ---")
     edge_creation_successful_count = 0
     edge_creation_failed_count = 0
     try:
@@ -147,42 +148,42 @@ def generate_multi_level_test_graph():
                 if source_id and target_id:
                     try:
                         lib.add_edge(sourceid=source_id, targetid=target_id, rel_type=rel_type, con=con)
-                        print(f"Created edge: {source_key} --({rel_type})--> {target_key}")
+                        olliePrint(f"Created edge: {source_key} --({rel_type})--> {target_key}")
                         edge_creation_successful_count += 1
                     except Exception as e:
-                        print(f"ERROR creating edge from '{source_key}' ({source_id}) to '{target_key}' ({target_id}) with rel_type '{rel_type}': {e}")
+                        olliePrint(f"ERROR creating edge from '{source_key}' ({source_id}) to '{target_key}' ({target_id}) with rel_type '{rel_type}': {e}")
                         edge_creation_failed_count += 1
                 else:
-                    print(f"Skipping edge from '{source_key}' to '{target_key}' due to missing node(s).")
+                    olliePrint(f"Skipping edge from '{source_key}' to '{target_key}' due to missing node(s).")
                     edge_creation_failed_count += 1
             
             if edge_creation_successful_count > 0:
-                 print(f"  Successfully created {edge_creation_successful_count} edges.")
+                 olliePrint(f"  Successfully created {edge_creation_successful_count} edges.")
             if edge_creation_failed_count > 0:
-                 print(f"  Failed to create {edge_creation_failed_count} edges. See errors above.")
+                 olliePrint(f"  Failed to create {edge_creation_failed_count} edges. See errors above.")
             if edge_creation_successful_count == 0 and edge_creation_failed_count == 0:
-                 print("  No edges were attempted or created (possibly due to all nodes failing creation).")
+                 olliePrint("  No edges were attempted or created (possibly due to all nodes failing creation).")
 
     except Exception as e:
-        print(f"  Major error during edge creation phase: {e}")
+        olliePrint(f"  Major error during edge creation phase: {e}")
         
     return [nid for nid in node_ids.values() if nid is not None]
 
 # Create the multi-level test graph
 created_node_ids = generate_multi_level_test_graph()
 
-print("\nMulti-level deterministic test graph generation complete!")
+olliePrint("\nMulti-level deterministic test graph generation complete!")
 if created_node_ids:
-    print(f"Successfully created {len(created_node_ids)} memory nodes.")
+    olliePrint(f"Successfully created {len(created_node_ids)} memory nodes.")
     
     # Count edges to inform user about test data size
     try:
         with lib.duckdb.connect(lib.DB_FILE) as con:
             edge_count = con.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
-            print(f"Successfully created {edge_count} edges between memory nodes.")
+            olliePrint(f"Successfully created {edge_count} edges between memory nodes.")
             
             # Print nodes with most connections for reference
-            print("\nTop 5 most connected nodes (these should orbit F.R.E.D. directly):")
+            olliePrint("\nTop 5 most connected nodes (these should orbit F.R.E.D. directly):")
             most_connected = con.execute("""
                 SELECT n.nodeid, n.label, COUNT(e.sourceid) + COUNT(e2.targetid) as edge_count
                 FROM nodes n
@@ -194,10 +195,10 @@ if created_node_ids:
             """).fetchall()
             
             for i, (node_id, label, count) in enumerate(most_connected, 1):
-                print(f"{i}. {label} - {count} connections")
+                olliePrint(f"{i}. {label} - {count} connections")
     except Exception as e:
-        print(f"Error retrieving statistics: {e}")
+        olliePrint(f"Error retrieving statistics: {e}")
 else:
-    print("No memory nodes were successfully created. Please check the logs for errors.")
+    olliePrint("No memory nodes were successfully created. Please check the logs for errors.")
     
-print("\nYou can now restart app.py and view the memory visualization in your browser.") 
+olliePrint("\nYou can now restart app.py and view the memory visualization in your browser.") 

--- a/start_fred_with_webrtc.py
+++ b/start_fred_with_webrtc.py
@@ -14,6 +14,7 @@ import time
 import aiohttp
 from config import config
 from ollietec_theme import apply_theme, banner, startup_block
+from ollie_print import olliePrint
 
 # Global variable to store tunnel info
 tunnel_info = {"webrtc_server": None, "main_url": None}
@@ -28,7 +29,7 @@ apply_theme()
 async def start_ngrok_tunnel():
     """Start ngrok tunnel asynchronously."""
     try:
-        print("[SHELTER-NET] Establishing external communication tunnel...")
+        olliePrint("[SHELTER-NET] Establishing external communication tunnel...")
         ngrok_process = await asyncio.create_subprocess_exec(
             "ngrok", "http", str(config.WEBRTC_PORT),
             "--log", "stdout",
@@ -47,27 +48,27 @@ async def start_ngrok_tunnel():
                         if tunnel['config']['addr'].endswith(str(config.WEBRTC_PORT)):
                             public_url = tunnel['public_url']
                             tunnel_info["webrtc_server"] = public_url
-                            print(f"[SUCCESS] External tunnel established: {public_url}")
-                            print("╔" + "═" * 78 + "╗")
-                            print("║" + f"{'🌐 NGROK TUNNEL URL FOR PI GLASSES:':^78}" + "║")
-                            print("║" + f"{public_url:^78}" + "║")
-                            print("║" + f"{'Use this URL on your Pi: python client.py --server {url}':^78}".format(url=public_url) + "║")
-                            print("╚" + "═" * 78 + "╝")
+                            olliePrint(f"[SUCCESS] External tunnel established: {public_url}")
+                            olliePrint("╔" + "═" * 78 + "╗")
+                            olliePrint("║" + f"{'🌐 NGROK TUNNEL URL FOR PI GLASSES:':^78}" + "║")
+                            olliePrint("║" + f"{public_url:^78}" + "║")
+                            olliePrint("║" + f"{'Use this URL on your Pi: python client.py --server {url}':^78}".format(url=public_url) + "║")
+                            olliePrint("╚" + "═" * 78 + "╝")
                             # Save tunnel info for Pi client
                             with open('tunnel_info.json', 'w') as f:
                                 json.dump({"webrtc_server": public_url}, f)
                             return ngrok_process
             except Exception as e:
-                print(f"[WARNING] Tunnel status unavailable via API: {e}")
+                olliePrint(f"[WARNING] Tunnel status unavailable via API: {e}")
         
         return ngrok_process
     except Exception as e:
-        print(f"[ERROR] External tunnel establishment failed: {e}")
+        olliePrint(f"[ERROR] External tunnel establishment failed: {e}")
         return None
 
 async def run_server(name, command):
     """Run a server command as a subprocess."""
-    print(f"🚀 Starting {name}...")
+    olliePrint(f"🚀 Starting {name}...")
     process = await asyncio.create_subprocess_exec(
         sys.executable, command,
         stdout=sys.stdout,
@@ -81,27 +82,27 @@ async def run_with_ngrok():
     ngrok_process = None
     
     if config.NGROK_ENABLED:
-        print("[SHELTER-NET] External tunnel protocols enabled...")
+        olliePrint("[SHELTER-NET] External tunnel protocols enabled...")
         ngrok_process = await start_ngrok_tunnel()
         if ngrok_process:
-            print("[SUCCESS] External communications link established")
+            olliePrint("[SUCCESS] External communications link established")
             # Display current tunnel info prominently
             if tunnel_info.get("webrtc_server"):
-                print("\n" + "="*80)
-                print(f"🌐 CURRENT NGROK TUNNEL: {tunnel_info['webrtc_server']}")
-                print("="*80)
-                print(f"📱 Pi Command: python client.py --server {tunnel_info['webrtc_server']}")
-                print("="*80 + "\n")
+                olliePrint("\n" + "="*80)
+                olliePrint(f"🌐 CURRENT NGROK TUNNEL: {tunnel_info['webrtc_server']}")
+                olliePrint("="*80)
+                olliePrint(f"📱 Pi Command: python client.py --server {tunnel_info['webrtc_server']}")
+                olliePrint("="*80 + "\n")
         else:
-            print("[WARNING] External tunnel failed - operating in local mode only")
+            olliePrint("[WARNING] External tunnel failed - operating in local mode only")
     else:
-        print("[LOCAL] External tunnel disabled - shelter network access only")
+        olliePrint("[LOCAL] External tunnel disabled - shelter network access only")
     
     try:
         await run_webrtc_server_async()
     finally:
         if ngrok_process:
-            print("[SHELTER-NET] Terminating external communication tunnel...")
+            olliePrint("[SHELTER-NET] Terminating external communication tunnel...")
             ngrok_process.terminate()
             await ngrok_process.wait()
 
@@ -112,7 +113,7 @@ def main():
     - WebRTC aiohttp server runs in the main thread's asyncio loop.
     """
     info_lines = ["[MAINFRAME] F.R.E.D. core intelligence systems ONLINE"]
-    print(startup_block("F.R.E.D. MAINFRAME", info_lines))
+    olliePrint(startup_block("F.R.E.D. MAINFRAME", info_lines))
 
     # 1. Run the Flask/SocketIO server in its own thread
     # This is necessary because it uses its own blocking eventlet server.
@@ -125,13 +126,13 @@ def main():
 
     # 2. Run the aiohttp WebRTC server with ngrok tunnel in the main thread using asyncio
     try:
-        print("[NETWORK] Initializing wasteland communication protocols...")
+        olliePrint("[NETWORK] Initializing wasteland communication protocols...")
         asyncio.run(run_with_ngrok())
     except KeyboardInterrupt:
-        print("\n[SHUTDOWN] F.R.E.D. mainframe shutting down...")
+        olliePrint("\n[SHUTDOWN] F.R.E.D. mainframe shutting down...")
     finally:
         # The servers are daemonized or will shut down on loop completion
-        print("[SHELTER-CORE] All systems offline. Stay safe out there.")
+        olliePrint("[SHELTER-CORE] All systems offline. Stay safe out there.")
         # Note: Proper cleanup of the WebRTC runner is handled within webrtc_server.py
         # on loop cancellation. The fred_thread is a daemon and will exit with the main thread.
 

--- a/static/mind-map.js
+++ b/static/mind-map.js
@@ -3,6 +3,20 @@
  * A physics-based 3D solar system with hierarchical orbital relationships
  * and detailed memory interaction
  */
+function olliePrint(msg, level = 'info') {
+    const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
+    const reset = '\x1b[0m';
+    const comments = {
+        info: 'Systems green across the board.',
+        success: 'Mission accomplished!',
+        warning: 'Caution: power conduit unstable.',
+        error: 'Critical failure detected!'
+    };
+    const ts = new Date().toISOString();
+    const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
+    const bar = '-'.repeat(header.length);
+    console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+}
 
 class MemorySolarSystem {
     constructor(container) {
@@ -453,13 +467,13 @@ class MemorySolarSystem {
     
     async loadConnectionData(memoryData) {
         // Load detailed connection information for each memory
-        console.log('Loading connection data for', memoryData.length, 'memories');
+        olliePrint('Loading connection data for', memoryData.length, 'memories');
         for (const memory of memoryData) {
             try {
                 const response = await fetch(`/api/memory/${memory.nodeid}/connections`);
                 if (response.ok) {
                     const connectionData = await response.json();
-                    console.log(`Loaded connections for memory ${memory.nodeid}:`, connectionData);
+                    olliePrint(`Loaded connections for memory ${memory.nodeid}:`, connectionData);
                     this.memoryConnections.set(memory.nodeid.toString(), connectionData);
                 } else {
                     console.warn(`Failed to load connections for memory ${memory.nodeid}: HTTP ${response.status}`);
@@ -469,7 +483,7 @@ class MemorySolarSystem {
                 this.memoryConnections.set(memory.nodeid.toString(), { connections: [] });
             }
         }
-        console.log('Finished loading connection data. Total connections loaded:', this.memoryConnections.size);
+        olliePrint('Finished loading connection data. Total connections loaded:', this.memoryConnections.size);
     }
     
     createHierarchicalMemorySystem(memoryData) {
@@ -972,7 +986,7 @@ class MemorySolarSystem {
         this.selectedMemory = memoryData;
         
         // Debug: log the memory data structure to understand what we're working with
-        console.log('Memory data for details panel:', memoryData);
+        olliePrint('Memory data for details panel:', memoryData);
         
         // Update panel content
         const panel = this.detailsPanel;
@@ -1003,7 +1017,7 @@ class MemorySolarSystem {
             connections = connectionData.connections || [];
         }
         
-        console.log(`Found ${connections.length} connections for memory ${memoryData.nodeid}:`, connections);
+        olliePrint(`Found ${connections.length} connections for memory ${memoryData.nodeid}:`, connections);
         
         if (connections.length > 0) {
             connections.slice(0, 10).forEach(connection => { // Show max 10 connections
@@ -1310,7 +1324,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 script.src = urls[index];
                 
                 script.onload = () => {
-                    console.log(`Three.js loaded successfully from ${urls[index]}`);
+                    olliePrint(`Three.js loaded successfully from ${urls[index]}`);
                     window.mindMap = new MemorySolarSystem(container);
                 };
                 
@@ -1331,7 +1345,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             loadThreeJS(cdnUrls);
         } else {
-            console.log('Three.js already loaded, initializing solar system');
+            olliePrint('Three.js already loaded, initializing solar system');
             window.mindMap = new MemorySolarSystem(container);
         }
     }
@@ -1346,7 +1360,7 @@ window.addEventListener('beforeunload', () => {
 
 // Fallback 2D visualization if Three.js fails to load
 function createFallbackVisualization(container) {
-    console.log('Creating fallback 2D memory visualization');
+    olliePrint('Creating fallback 2D memory visualization');
     
     // Create canvas for 2D visualization
     const canvas = document.createElement('canvas');

--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,13 @@
+function olliePrint(msg, level = 'info') {
+  const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
+  const reset = '\x1b[0m';
+  const comments = {info: 'Systems green across the board.', success: 'Mission accomplished!', warning: 'Caution: power conduit unstable.', error: 'Critical failure detected!'};
+  const ts = new Date().toISOString();
+  const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
+  const bar = '-'.repeat(header.length);
+  console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+}
+
 const messageForm = document.getElementById('message-form');
 const messageInput = document.getElementById('message-input');
 const chatHistory = document.getElementById('chat-history');
@@ -261,14 +271,14 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 muteFredButton.style.background = 'rgba(var(--fred-error), 0.1)';
             }
-            console.log(`F.R.E.D. Muted: ${isFredMuted}`);
+            olliePrint(`F.R.E.D. Muted: ${isFredMuted}`);
         });
     }
     
     // Initialize system status
     updateSystemStatus('Ready', 'success');
     
-    console.log('F.R.E.D. Interface Initialized');
+    olliePrint('F.R.E.D. Interface Initialized');
 });
 
 // Check local storage on load - Default to dark mode
@@ -503,14 +513,14 @@ document.addEventListener('keydown', (event) => {
 //             memoryContentDisplay.textContent = `Accessing ${memoryType} memory...`;
 //             memoryContentDisplay.style.opacity = '0.7';
 //         }, 300);
-//         console.log(`Switched to ${memoryType} memory view.`);
+//         olliePrint(`Switched to ${memoryType} memory view.`);
 
 //     }
 // });
 
 // Initial Setup
 adjustTextareaHeight(messageInput);
-console.log('Fred UI Initialized');
+olliePrint('Fred UI Initialized');
 
 // --- Potential Future Enhancements ---
 // Additional features to implement:
@@ -520,4 +530,4 @@ console.log('Fred UI Initialized');
 // - Implement actual memory content loading/display
 // - More robust Markdown rendering
 
-console.log('Clay UI Chat Initialized'); 
+olliePrint('Clay UI Chat Initialized'); 

--- a/static/speech.js
+++ b/static/speech.js
@@ -1,6 +1,21 @@
 // Speech-to-Text functionality for F.R.E.D. v2
 // Improved implementation using patterns from F.R.E.D. v1
 
+function olliePrint(msg, level = 'info') {
+    const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
+    const reset = '\x1b[0m';
+    const comments = {
+        info: 'Systems green across the board.',
+        success: 'Mission accomplished!',
+        warning: 'Caution: power conduit unstable.',
+        error: 'Critical failure detected!'
+    };
+    const ts = new Date().toISOString();
+    const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
+    const bar = '-'.repeat(header.length);
+    console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+}
+
 class SpeechSystem {
     constructor() {
         this.socket = null;
@@ -40,19 +55,19 @@ class SpeechSystem {
     setupSocketEvents() {
         // Connection events
         this.socket.on('connect', () => {
-            console.log('Connected to F.R.E.D. speech system');
+            olliePrint('Connected to F.R.E.D. speech system');
             this.updateStatus('Connected', 'online');
         });
         
         this.socket.on('disconnect', () => {
-            console.log('Disconnected from F.R.E.D.');
+            olliePrint('Disconnected from F.R.E.D.');
             this.updateStatus('Disconnected', 'offline');
             this.stopRecording();
         });
         
         // Status updates
         this.socket.on('status', (data) => {
-            console.log('Status update:', data.message);
+            olliePrint('Status update:', data.message);
             this.updateStatus(data.message, 'online');
             
             // Only update sttEnabled from server if we're not currently toggling
@@ -71,7 +86,7 @@ class SpeechSystem {
         
         // F.R.E.D. acknowledgments (new v1-inspired feature)
         this.socket.on('fred_acknowledgment', (data) => {
-            console.log('F.R.E.D. acknowledgment:', data.text);
+            olliePrint('F.R.E.D. acknowledgment:', data.text);
             this.showFeedback('F.R.E.D. is listening...', 'listening');
             this.isListening = true;
             
@@ -81,7 +96,7 @@ class SpeechSystem {
         
         // Transcription results
         this.socket.on('transcription_result', (data) => {
-            console.log('Transcription:', data.text);
+            olliePrint('Transcription:', data.text);
             
             // Check if this is a wake word activation (silent mode)
             const wakeWords = ['fred', 'hey fred', 'okay fred', 'hi fred', 'excuse me fred', 'fred are you there'];
@@ -89,7 +104,7 @@ class SpeechSystem {
             
             if (isWakeWord && !this.isListening) {
                 // Silent wake word activation - just show listening feedback
-                console.log('Wake word detected - activating silent listening mode');
+                olliePrint('Wake word detected - activating silent listening mode');
                 this.showFeedback('Listening...', 'listening');
                 this.isListening = true;
                 // Don't add wake word to chat history
@@ -127,7 +142,7 @@ class SpeechSystem {
     
     initializeSpeech() {
         // DISABLED: Web audio capture - backend now uses direct microphone access
-        console.log('Using direct backend microphone access - web audio disabled');
+        olliePrint('Using direct backend microphone access - web audio disabled');
         this.updateStatus('Backend handling microphone directly', 'online');
         this.startSTT();
         
@@ -171,7 +186,7 @@ class SpeechSystem {
     
     setupAudioProcessing(stream) {
         // DISABLED: Audio processing now handled by backend directly
-        console.log('Audio processing disabled - backend handles microphone directly');
+        olliePrint('Audio processing disabled - backend handles microphone directly');
         return;
         
         // COMMENTED OUT: Web audio processing
@@ -187,13 +202,13 @@ class SpeechSystem {
             this.setupLegacyAudioProcessing();
         }
         
-        console.log('Audio processing set up successfully');
+        olliePrint('Audio processing set up successfully');
         */
     }
     
     async setupModernAudioProcessing() {
         // DISABLED: Modern audio processing - backend handles audio directly
-        console.log('Modern audio processing disabled - backend handles microphone');
+        olliePrint('Modern audio processing disabled - backend handles microphone');
         return;
         
         // COMMENTED OUT: AudioWorklet processing
@@ -256,7 +271,7 @@ class SpeechSystem {
             this.microphone.connect(this.processor);
             this.processor.connect(this.audioContext.destination);
             
-            console.log('Using modern AudioWorkletNode for audio processing');
+            olliePrint('Using modern AudioWorkletNode for audio processing');
             
         } catch (workletError) {
             console.warn('AudioWorkletNode setup failed, falling back to ScriptProcessorNode:', workletError);
@@ -267,7 +282,7 @@ class SpeechSystem {
     
     setupLegacyAudioProcessing() {
         // DISABLED: Legacy audio processing - backend handles audio directly
-        console.log('Legacy audio processing disabled - backend handles microphone');
+        olliePrint('Legacy audio processing disabled - backend handles microphone');
         return;
         
         // COMMENTED OUT: ScriptProcessorNode processing
@@ -324,7 +339,7 @@ class SpeechSystem {
         this.socket.emit('start_stt');
         this.isRecording = true;
         this.updateStatus('Waiting for wake word...', 'listening');
-        console.log('Started speech-to-text');
+        olliePrint('Started speech-to-text');
     }
     
     stopSTT() {
@@ -333,7 +348,7 @@ class SpeechSystem {
         this.isListening = false;
         this.updateStatus('Speech recognition stopped', 'offline');
         this.hideFeedback();
-        console.log('Stopped speech-to-text');
+        olliePrint('Stopped speech-to-text');
     }
     
     toggleSpeech() {
@@ -467,6 +482,6 @@ class SpeechSystem {
 
 // Initialize speech system when page loads
 document.addEventListener('DOMContentLoaded', () => {
-    console.log('Initializing F.R.E.D. speech system...');
+    olliePrint('Initializing F.R.E.D. speech system...');
     window.speechSystem = new SpeechSystem();
 }); 

--- a/webrtc_server.py
+++ b/webrtc_server.py
@@ -14,6 +14,7 @@ import ssl
 import numpy as np
 from scipy.signal import resample_poly
 from ollietec_theme import apply_theme, banner, startup_block
+from ollie_print import olliePrint
 
 # Import configuration
 from config import config
@@ -36,17 +37,17 @@ runner = None
 async def request_frame_from_client(client_ip):
     """Request a fresh frame from a specific client"""
     if client_ip not in client_video_tracks:
-        print(f"⚠️ No video track available for {client_ip}")
+        olliePrint(f"⚠️ No video track available for {client_ip}")
         return None
     
     try:
         track = client_video_tracks[client_ip]
-        print(f"📸 Requesting fresh frame from {client_ip}")
+        olliePrint(f"📸 Requesting fresh frame from {client_ip}")
         frame = await track.recv()
-        print(f"✅ Fresh frame received from {client_ip} (size: {frame.width}x{frame.height})")
+        olliePrint(f"✅ Fresh frame received from {client_ip} (size: {frame.width}x{frame.height})")
         return frame
     except Exception as e:
-        print(f"❌ Failed to request frame from {client_ip}: {e}")
+        olliePrint(f"❌ Failed to request frame from {client_ip}: {e}")
         return None
 
 # SocketIO client to connect to main F.R.E.D. server
@@ -178,24 +179,24 @@ async def offer(request):
         def on_datachannel(channel):
             data_channels.add(channel)
             pi_clients.add(channel)  # Track Pi clients
-            print(f"[ARMLINK] Data channel '{channel.label}' established with field operative at {client_ip}")
+            olliePrint(f"[ARMLINK] Data channel '{channel.label}' established with field operative at {client_ip}")
             
             # Notify vision service that Pi is connected
             vision_service.set_pi_connection_status(True)
-            print(f"[OPTICS] ArmLink visual sensors ONLINE - initiating reconnaissance protocols")
+            olliePrint(f"[OPTICS] ArmLink visual sensors ONLINE - initiating reconnaissance protocols")
             
             # Check if this is a local STT client
             client_type = params.get('client_type', 'unknown')
             is_local_stt = 'local_stt' in client_type
             
             if is_local_stt:
-                print(f"🧠 [LOCAL STT] Client using on-device transcription - text-only mode")
+                olliePrint(f"🧠 [LOCAL STT] Client using on-device transcription - text-only mode")
             
             @channel.on('message')
             def on_message(message):
                 # Handle heartbeat messages
                 if message == '[HEARTBEAT]':
-                    print(f"[VITAL-MONITOR] ArmLink heartbeat confirmed from {client_ip}")
+                    olliePrint(f"[VITAL-MONITOR] ArmLink heartbeat confirmed from {client_ip}")
                     channel.send('[HEARTBEAT_ACK]')
                 elif is_local_stt:
                     # Handle transcribed text from Pi
@@ -205,31 +206,31 @@ async def offer(request):
                         if data.get('type') == 'transcription':
                             text = data.get('text', '').strip()
                             if text:
-                                print(f"🗣️ [PI TRANSCRIPTION] '{text}' from {client_ip}")
+                                olliePrint(f"🗣️ [PI TRANSCRIPTION] '{text}' from {client_ip}")
                                 # Process the transcribed text (same as old audio processing)
                                 process_pi_transcription(text, from_pi=True)
                     except json.JSONDecodeError:
                         # Handle plain text messages
                         if message.strip():
-                            print(f"🗣️ [PI TRANSCRIPTION] '{message.strip()}' from {client_ip}")
+                            olliePrint(f"🗣️ [PI TRANSCRIPTION] '{message.strip()}' from {client_ip}")
                             process_pi_transcription(message.strip(), from_pi=True)
                 else:
-                    print(f"[ARMLINK COMM] Field operative message: {message}")
+                    olliePrint(f"[ARMLINK COMM] Field operative message: {message}")
             
             @channel.on('close')
             def on_close():
                 data_channels.discard(channel)
                 pi_clients.discard(channel)
-                print(f"[ARMLINK] Data channel '{channel.label}' closed from {client_ip}")
+                olliePrint(f"[ARMLINK] Data channel '{channel.label}' closed from {client_ip}")
                 
                 # If no more Pi clients, stop vision processing
                 if not pi_clients:
                     vision_service.set_pi_connection_status(False)
-                    print(f"[OPTICS] All ArmLinks disconnected - reconnaissance protocols OFFLINE")
+                    olliePrint(f"[OPTICS] All ArmLinks disconnected - reconnaissance protocols OFFLINE")
 
         @pc.on('track')
         async def on_track(track):
-            print(f"[SIGNAL] {track.kind.upper()} link established with field operative {client_ip}")
+            olliePrint(f"[SIGNAL] {track.kind.upper()} link established with field operative {client_ip}")
             
             if track.kind == 'audio':
                 # Check if this is a local STT client
@@ -237,7 +238,7 @@ async def offer(request):
                 is_local_stt = 'local_stt' in client_type
                 
                 if is_local_stt:
-                    print("[AUDIO] Client uses local STT - skipping server audio processing")
+                    olliePrint("[AUDIO] Client uses local STT - skipping server audio processing")
                     # Just consume frames without processing to prevent buffer buildup
                     async def consume_audio_frames_minimal():
                         try:
@@ -246,15 +247,15 @@ async def offer(request):
                                 frame = await track.recv()
                                 frame_count += 1
                                 if frame_count == 1:
-                                    print(f"[AUDIO] Receiving audio frames from {client_ip} (not processing - local STT active)")
+                                    olliePrint(f"[AUDIO] Receiving audio frames from {client_ip} (not processing - local STT active)")
                                 elif frame_count % 5000 == 0:  # Very minimal logging
-                                    print(f"[AUDIO] {frame_count} frames received (local STT mode)")
+                                    olliePrint(f"[AUDIO] {frame_count} frames received (local STT mode)")
                         except Exception as e:
-                            print(f"[AUDIO] Audio stream ended: {e}")
+                            olliePrint(f"[AUDIO] Audio stream ended: {e}")
                     
                     asyncio.create_task(consume_audio_frames_minimal())
                 else:
-                    print("[AUDIO] Voice communication protocols active (server STT)")
+                    olliePrint("[AUDIO] Voice communication protocols active (server STT)")
                     frame_count = 0
                     
                     # Create a task to consume audio frames from the track
@@ -272,10 +273,10 @@ async def offer(request):
                                 frame_count += 1
 
                                 if frame_count == 1:
-                                    print(f"[AUDIO] First transmission received from {client_ip}")
+                                    olliePrint(f"[AUDIO] First transmission received from {client_ip}")
                                 # Reduced frequency of frame logging for conciseness
                                 elif frame_count % 2000 == 0:  # Every ~40 seconds instead of every 10
-                                    print(f"[AUDIO] {frame_count} frames processed")
+                                    olliePrint(f"[AUDIO] {frame_count} frames processed")
 
                                 pcm = frame.to_ndarray()
 
@@ -306,7 +307,7 @@ async def offer(request):
                                         pcm = pcm_resampled.astype(np.float32)
                                         
                                     except Exception as rs_err:
-                                        print(f"[WARNING] Audio resampling error ({input_sr}->{target_sr}): {rs_err}")
+                                        olliePrint(f"[WARNING] Audio resampling error ({input_sr}->{target_sr}): {rs_err}")
                                         # Fallback: simple decimation
                                         if input_sr == 48000 and target_sr == 16000:
                                             pcm = pcm[::3].astype(np.float32) / 32768.0 if pcm.dtype == np.int16 else pcm[::3]
@@ -327,10 +328,10 @@ async def offer(request):
                                     total_samples = 0
                                     # Reduced frequency of chunk processing logs
                                     if frame_count % 3000 == 0:  # Much less frequent
-                                        print(f"[PROCESSING] Speech data sent to recognition system")
+                                        olliePrint(f"[PROCESSING] Speech data sent to recognition system")
 
                         except Exception as e:
-                            print(f"[ERROR] Audio transmission ended: {e}")
+                            olliePrint(f"[ERROR] Audio transmission ended: {e}")
                         finally:
                             # graceful exit when track ends
                             return
@@ -338,7 +339,7 @@ async def offer(request):
                     asyncio.create_task(consume_audio_frames())
                 
             elif track.kind == 'video':
-                print("[OPTICS] Visual reconnaissance feed active")
+                olliePrint("[OPTICS] Visual reconnaissance feed active")
                 frame_count = 0
                 
                 # Store track for on-demand frame requests
@@ -348,13 +349,13 @@ async def offer(request):
                 try:
                     frame = await track.recv()
                     frame_count += 1
-                    print(f"[OPTICS] Visual feed confirmed ({frame.width}x{frame.height})")
+                    olliePrint(f"[OPTICS] Visual feed confirmed ({frame.width}x{frame.height})")
                     
                     # Store frame for vision processing
                     vision_service.store_latest_frame(frame)
                     
                 except Exception as e:
-                    print(f"[ERROR] Visual feed initialization failed: {e}")
+                    olliePrint(f"[ERROR] Visual feed initialization failed: {e}")
             
             # Add track to recorder safely
             if recorder:
@@ -367,9 +368,9 @@ async def offer(request):
         async def on_connectionstatechange():
             
             if pc.connectionState == 'connected':
-                print(f"[SUCCESS] ArmLink fully operational at {client_ip}")
+                olliePrint(f"[SUCCESS] ArmLink fully operational at {client_ip}")
             elif pc.connectionState in ('failed', 'closed'):
-                print(f"[DISCONNECT] ArmLink {client_ip} offline")
+                olliePrint(f"[DISCONNECT] ArmLink {client_ip} offline")
                 # Clean up video track reference
                 if client_ip in client_video_tracks:
                     del client_video_tracks[client_ip]
@@ -390,10 +391,10 @@ async def offer(request):
 # SocketIO event handlers for receiving responses from main F.R.E.D. server
 @sio_client.event
 async def connect():
-    print("[SHELTER-NET] Established secure link to F.R.E.D. mainframe")
+    olliePrint("[SHELTER-NET] Established secure link to F.R.E.D. mainframe")
     # Emit connection confirmation
     await sio_client.emit('webrtc_server_connected')
-    print("[BRIDGE] Wasteland communication network ONLINE - standing by for field operations")
+    olliePrint("[BRIDGE] Wasteland communication network ONLINE - standing by for field operations")
 
 @sio_client.event
 async def voice_response(data):
@@ -404,9 +405,9 @@ async def voice_response(data):
         for channel in data_channels.copy():
             try:
                 channel.send(response_text)
-                print(f"📱 Text sent to Pi: {response_text[:50]}...")
+                olliePrint(f"📱 Text sent to Pi: {response_text[:50]}...")
             except Exception as e:
-                print(f"Failed to send to Pi: {e}")
+                olliePrint(f"Failed to send to Pi: {e}")
                 data_channels.discard(channel)
 
 @sio_client.event
@@ -416,9 +417,9 @@ async def fred_acknowledgment(data):
     for channel in data_channels.copy():
         try:
             channel.send(f"[ACK] {ack_text}")
-            print(f"Sent acknowledgment to Pi: {ack_text}")
+            olliePrint(f"Sent acknowledgment to Pi: {ack_text}")
         except Exception as e:
-            print(f"Failed to send acknowledgment to Pi: {e}")
+            olliePrint(f"Failed to send acknowledgment to Pi: {e}")
             data_channels.discard(channel)
 
 @sio_client.event
@@ -429,8 +430,8 @@ async def fred_audio(data):
     audio_format = data.get('format', 'wav')
     
     if audio_b64:
-        print(f"[TRANSMISSION] Audio matrix received from F.R.E.D. ({len(audio_b64)} chars) → '{text[:50]}...'")
-        print(f"[NETWORK] {len(data_channels)} ArmLink device(s) in communication range")
+        olliePrint(f"[TRANSMISSION] Audio matrix received from F.R.E.D. ({len(audio_b64)} chars) → '{text[:50]}...'")
+        olliePrint(f"[NETWORK] {len(data_channels)} ArmLink device(s) in communication range")
         
         # Send audio to all connected Pi clients
         sent_count = 0
@@ -439,15 +440,15 @@ async def fred_audio(data):
                 message = f"[AUDIO_BASE64:{audio_format}]{audio_b64}"
                 channel.send(message)
                 sent_count += 1
-                print(f"[RELAY] Voice data transmitted to ArmLink #{sent_count} → '{text[:50]}...'")
+                olliePrint(f"[RELAY] Voice data transmitted to ArmLink #{sent_count} → '{text[:50]}...'")
             except Exception as e:
-                print(f"[ERROR] ArmLink #{sent_count+1} transmission failure: {e}")
+                olliePrint(f"[ERROR] ArmLink #{sent_count+1} transmission failure: {e}")
                 data_channels.discard(channel)
         
         if sent_count == 0:
-            print("[WARNING] No ArmLink devices available - audio transmission failed")
+            olliePrint("[WARNING] No ArmLink devices available - audio transmission failed")
         else:
-            print(f"[SUCCESS] Voice transmission complete → {sent_count} field operative(s) reached")
+            olliePrint(f"[SUCCESS] Voice transmission complete → {sent_count} field operative(s) reached")
         
         # Inform STT to pause listening during playback
         estimated_bytes = int(len(audio_b64) * 3 / 4)  # rough base64 decode
@@ -457,11 +458,11 @@ async def fred_audio(data):
         loop = asyncio.get_event_loop()
         loop.call_later(playback_seconds, lambda: stt_service.set_speaking_state(False))
     else:
-        print("[ERROR] No audio data in transmission from F.R.E.D. mainframe")
+        olliePrint("[ERROR] No audio data in transmission from F.R.E.D. mainframe")
 
 async def cleanup(app):
     # This is still valuable for graceful shutdown
-    print("🧹 Cleaning up server resources...")
+    olliePrint("🧹 Cleaning up server resources...")
     for pc in pcs:
         if pc.connectionState != "closed":
             await pc.close()
@@ -475,9 +476,9 @@ async def init_app(app):
     try:
         # Connect to main F.R.E.D. server
         await sio_client.connect('http://localhost:5000')
-        print("Connected to F.R.E.D. main server for response forwarding")
+        olliePrint("Connected to F.R.E.D. main server for response forwarding")
     except Exception as e:
-        print(f"Failed to connect to F.R.E.D. main server: {e}")
+        olliePrint(f"Failed to connect to F.R.E.D. main server: {e}")
 
 async def main():
     parser = argparse.ArgumentParser(description="F.R.E.D. WebRTC server")
@@ -518,7 +519,7 @@ async def main():
         f"🔢 Max connections: {MAX_CONNECTIONS}",
         f"🚀 Listening on http://{args.host}:{args.port}",
     ]
-    print(startup_block("WebRTC Server", info_lines))
+    olliePrint(startup_block("WebRTC Server", info_lines))
 
     # Keep server running until interrupted
     while True:
@@ -528,9 +529,9 @@ if __name__ == "__main__":
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        print("\n⌨️ Server shutting down manually...")
+        olliePrint("\n⌨️ Server shutting down manually...")
     finally:
         # This cleanup is for when running the file directly
         if runner:
             asyncio.run(runner.cleanup())
-        print("✅ Server shutdown complete.")
+        olliePrint("✅ Server shutdown complete.")


### PR DESCRIPTION
## Summary
- introduce `olliePrint` helper for coloured FRED banners
- switch every print/console.log/logger call to `olliePrint`
- add browser variant of `olliePrint` to JS assets
- avoid recursion in JS helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/script.js`
- `node --check static/mind-map.js`
- `node --check static/speech.js`


------
https://chatgpt.com/codex/tasks/task_e_685465bb06d88320b3e6b2ff77bf405b