### PR TITLE
Refactor logging to use olliePrint

### DIFF
--- a/memory/short_term_memory.py
+++ b/memory/short_term_memory.py
@@ -2,7 +2,6 @@ import sqlite3
 import json
 import numpy as np
 import requests
-import logging
 import threading
 import os
 from datetime import datetime
@@ -49,9 +48,9 @@ def init_stm_db():
                     message_range TEXT NOT NULL
                 )
             """)
-        logging.info("STM database initialized successfully")
+        olliePrint("STM database initialized successfully")
     except Exception as e:
-        logging.error(f"Failed to initialize STM database: {e}")
+        olliePrint(f"Failed to initialize STM database: {e}", level='error')
         raise
 
 def get_embedding(text: str) -> Optional[np.ndarray]:
@@ -68,7 +67,7 @@ def get_embedding(text: str) -> Optional[np.ndarray]:
             raise ValueError(f"Embedding dimension mismatch: expected {config.EMBEDDING_DIM}, got {len(embedding)}")
         return np.array(embedding, dtype=np.float32)
     except Exception as e:
-        logging.error(f"Failed to get embedding: {e}")
+        olliePrint(f"Failed to get embedding: {e}", level='error')
         return None
 
 def analyze_conversation_segment(messages: List[Dict], focus_start: int, focus_end: int, context_start: int, context_end: int) -> Optional[str]:
@@ -118,7 +117,7 @@ Key learnings from ONLY the marked ">>>" messages:"""
         return result if result else None
         
     except Exception as e:
-        logging.error(f"Failed to analyze conversation segment: {e}")
+        olliePrint(f"Failed to analyze conversation segment: {e}", level='error')
         return None
 
 def check_similarity_and_store(content: str, source_messages: List[Dict], message_range: str) -> bool:
@@ -146,7 +145,7 @@ def check_similarity_and_store(content: str, source_messages: List[Dict], messag
             max_similarity = np.max(similarities)
             
             if max_similarity > config.STM_SIMILARITY_THRESHOLD:
-                logging.info(f"STM content too similar (similarity: {max_similarity:.3f}), skipping storage")
+                olliePrint(f"STM content too similar (similarity: {max_similarity:.3f}), skipping storage")
                 return False
         
         # Store the new memory
@@ -176,11 +175,11 @@ def check_similarity_and_store(content: str, source_messages: List[Dict], messag
                     (to_remove,)
                 )
         
-        logging.info(f"Stored new STM: {content[:100]}...")
+        olliePrint(f"Stored new STM: {content[:100]}...")
         return True
         
     except Exception as e:
-        logging.error(f"Failed to check similarity and store: {e}")
+        olliePrint(f"Failed to check similarity and store: {e}", level='error')
         return False
 
 def query_stm_context(user_message: str) -> str:
@@ -228,7 +227,7 @@ def query_stm_context(user_message: str) -> str:
 (END RECENTLY POSSIBLY RELATED CONTEXT)"""
         
     except Exception as e:
-        logging.error(f"Failed to query STM context: {e}")
+        olliePrint(f"Failed to query STM context: {e}", level='error')
         return ""
 
 def process_stm_analysis(conversation_history: List[Dict], last_analyzed_index: int, current_total: int):
@@ -258,7 +257,7 @@ def process_stm_analysis(conversation_history: List[Dict], last_analyzed_index: 
         message_range = f"focus {focus_start}-{focus_end} (context {context_start+1}-{context_end})"
         
         # Analyze the conversation segment
-        logging.info(f"Analyzing STM for {message_range}")
+        olliePrint(f"Analyzing STM for {message_range}")
         learnings = analyze_conversation_segment(
             context_messages, 
             focus_start, 
@@ -272,14 +271,14 @@ def process_stm_analysis(conversation_history: List[Dict], last_analyzed_index: 
             focus_messages = conversation_history[last_analyzed_index:current_total]
             success = check_similarity_and_store(learnings, focus_messages, message_range)
             if success:
-                logging.info(f"STM analysis complete for {message_range}")
+                olliePrint(f"STM analysis complete for {message_range}")
             else:
-                logging.info(f"STM analysis skipped (duplicate) for {message_range}")
+                olliePrint(f"STM analysis skipped (duplicate) for {message_range}")
         else:
-            logging.warning(f"STM analysis failed for {message_range}")
+            olliePrint(f"STM analysis failed for {message_range}", level='warning')
             
     except Exception as e:
-        logging.error(f"STM background processing failed: {e}")
+        olliePrint(f"STM background processing failed: {e}", level='error')
 
 # Initialize database on import
 init_stm_db() 

--- a/pi_client/fred_pi_client.py
+++ b/pi_client/fred_pi_client.py
@@ -28,7 +28,6 @@ import subprocess
 import threading
 import queue
 import numpy as np
-import logging
 from typing import Optional, Callable
 import vosk
 
@@ -42,7 +41,6 @@ from aiortc import RTCPeerConnection, RTCSessionDescription, RTCConfiguration, R
 # Apply theming to all prints
 apply_theme()
 
-logger = logging.getLogger(__name__)
 
 class FREDPiSTTService:
     """

--- a/pi_client/install_local_stt.sh
+++ b/pi_client/install_local_stt.sh
@@ -35,10 +35,11 @@ echo "🧠 Downloading tiny.en Whisper model..."
 python3 -c "
 import os
 from faster_whisper import WhisperModel
-print('Downloading tiny.en model with int8 quantization...')
+from ollie_print import olliePrint
+olliePrint('Downloading tiny.en model with int8 quantization...')
 model = WhisperModel('tiny.en', device='cpu', compute_type='int8')
-print('✅ Model downloaded successfully!')
-print('Model cached for offline use')
+olliePrint('✅ Model downloaded successfully!', level='success')
+olliePrint('Model cached for offline use')
 "
 
 # Test audio setup
@@ -46,19 +47,20 @@ echo "🎤 Testing audio setup..."
 python3 -c "
 import sounddevice as sd
 import numpy as np
-print('Available audio devices:')
-print(sd.query_devices())
-print()
-print('Testing audio capture...')
+from ollie_print import olliePrint
+olliePrint('Available audio devices:')
+olliePrint(sd.query_devices())
+olliePrint('')
+olliePrint('Testing audio capture...')
 try:
     # Test 1-second recording
     audio = sd.rec(int(1 * 16000), samplerate=16000, channels=1, dtype='float32')
     sd.wait()
     level = np.abs(audio).mean()
-    print(f'✅ Audio capture working! Level: {level:.4f}')
+    olliePrint(f'✅ Audio capture working! Level: {level:.4f}', level='success')
 except Exception as e:
-    print(f'❌ Audio test failed: {e}')
-    print('Check microphone permissions and connections')
+    olliePrint(f'❌ Audio test failed: {e}', level='error')
+    olliePrint('Check microphone permissions and connections', level='warning')
 "
 
 # Test the local STT service
@@ -66,16 +68,17 @@ echo "🧪 Testing local STT service..."
 python3 -c "
 try:
     from pi_stt_service import pi_stt_service
-    print('✅ Pi STT service import successful!')
+    from ollie_print import olliePrint
+    olliePrint('✅ Pi STT service import successful!', level='success')
     
     if pi_stt_service.initialize():
-        print('✅ Whisper model initialization successful!')
-        print('🎯 Ready for local speech recognition')
+        olliePrint('✅ Whisper model initialization successful!', level='success')
+        olliePrint('🎯 Ready for local speech recognition')
         pi_stt_service.stop_processing()
     else:
-        print('❌ STT initialization failed')
+        olliePrint('❌ STT initialization failed', level='error')
 except Exception as e:
-    print(f'❌ STT test failed: {e}')
+    olliePrint(f'❌ STT test failed: {e}', level='error')
 "
 
 echo

--- a/scripts/forget_memory.sh
+++ b/scripts/forget_memory.sh
@@ -26,6 +26,7 @@ PYTHON_CMD=$(command -v python3 || command -v python)
 cat << EOF > "$PYTHON_SCRIPT"
 import sys
 import os
+from ollie_print import olliePrint
 
 # Add the project root to the Python path to find the memory module
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -36,19 +37,19 @@ try:
     from memory import librarian
     db_path = os.path.join(project_root, 'memory', 'memory.db')
     if not os.path.exists(db_path):
-        print(f"Error: Database file not found at {db_path}")
+        olliePrint(f"Error: Database file not found at {db_path}", level='error')
         sys.exit(1)
     librarian.DB_FILE = db_path
-    print(f"Running forget_old_memories (cutoff: 180 days)... Database: {librarian.DB_FILE}")
+    olliePrint(f"Running forget_old_memories (cutoff: 180 days)... Database: {librarian.DB_FILE}")
     deleted_count = librarian.forget_old_memories(days_old=180)
-    print(f"Forget script finished. Deleted {deleted_count} nodes.")
+    olliePrint(f"Forget script finished. Deleted {deleted_count} nodes.", level='success')
     sys.exit(0)
 except ImportError as e:
-    print(f"Error importing librarian module: {e}")
-    print("Ensure the script is run from the project root or the Python path is set correctly.")
+    olliePrint(f"Error importing librarian module: {e}", level='error')
+    olliePrint("Ensure the script is run from the project root or the Python path is set correctly.", level='warning')
     sys.exit(1)
 except Exception as e:
-    print(f"An error occurred: {e}")
+    olliePrint(f"An error occurred: {e}", level='error')
     sys.exit(1)
 EOF
 

--- a/stt_service.py
+++ b/stt_service.py
@@ -1,7 +1,6 @@
 import io
 import threading
 import time
-import logging
 import numpy as np
 import soundfile as sf
 from faster_whisper import WhisperModel
@@ -33,7 +32,6 @@ def print_transcription_to_terminal(text, source="TRANSCRIPTION"):
     )
     olliePrint("".join(message))
 
-logger = logging.getLogger(__name__)
 
 class STTService:
     def __init__(self):

--- a/vision_service.py
+++ b/vision_service.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import io
 import time
-import logging
 from PIL import Image
 import ollama
 import numpy as np
@@ -12,7 +11,6 @@ from ollie_print import olliePrint
 
 apply_theme()
 
-logger = logging.getLogger(__name__)
 
 class VisionService:
     def __init__(self):


### PR DESCRIPTION
## Summary
- remove `logging` dependencies
- route Python log calls through `olliePrint`
- update shell helper scripts to use `olliePrint`
- add verbose message in WebRTC server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854d698e2ac8320a76f5e2b58256ecb