### PR TITLE
Fix olliePrint formatting in browser logs

### DIFF
--- a/static/mind-map.js
+++ b/static/mind-map.js
@@ -4,8 +4,12 @@
  * and detailed memory interaction
  */
 function olliePrint(msg, level = 'info') {
-    const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
-    const reset = '\x1b[0m';
+    const colors = {
+        info: 'color: blue',
+        success: 'color: green',
+        warning: 'color: orange',
+        error: 'color: red'
+    };
     const comments = {
         info: 'Systems green across the board.',
         success: 'Mission accomplished!',
@@ -15,7 +19,8 @@ function olliePrint(msg, level = 'info') {
     const ts = new Date().toISOString();
     const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
     const bar = '-'.repeat(header.length);
-    console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+    const style = colors[level] || colors.info;
+    console.log(`${bar}\n${header}\n${bar}\n%c${msg}%c ${comments[level] || ''}`, style, '');
 }
 
 class MemorySolarSystem {

--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,21 @@
 function olliePrint(msg, level = 'info') {
-  const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
-  const reset = '\x1b[0m';
-  const comments = {info: 'Systems green across the board.', success: 'Mission accomplished!', warning: 'Caution: power conduit unstable.', error: 'Critical failure detected!'};
+  const colors = {
+    info: 'color: blue',
+    success: 'color: green',
+    warning: 'color: orange',
+    error: 'color: red'
+  };
+  const comments = {
+    info: 'Systems green across the board.',
+    success: 'Mission accomplished!',
+    warning: 'Caution: power conduit unstable.',
+    error: 'Critical failure detected!'
+  };
   const ts = new Date().toISOString();
   const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
   const bar = '-'.repeat(header.length);
-  console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+  const style = colors[level] || colors.info;
+  console.log(`${bar}\n${header}\n${bar}\n%c${msg}%c ${comments[level] || ''}`, style, '');
 }
 
 const messageForm = document.getElementById('message-form');

--- a/static/speech.js
+++ b/static/speech.js
@@ -2,8 +2,12 @@
 // Improved implementation using patterns from F.R.E.D. v1
 
 function olliePrint(msg, level = 'info') {
-    const colors = {info: '\x1b[34m', success: '\x1b[32m', warning: '\x1b[33m', error: '\x1b[31m'};
-    const reset = '\x1b[0m';
+    const colors = {
+        info: 'color: blue',
+        success: 'color: green',
+        warning: 'color: orange',
+        error: 'color: red'
+    };
     const comments = {
         info: 'Systems green across the board.',
         success: 'Mission accomplished!',
@@ -13,7 +17,8 @@ function olliePrint(msg, level = 'info') {
     const ts = new Date().toISOString();
     const header = `BROWSER [${ts}] - Designed by Ollie-Tec`;
     const bar = '-'.repeat(header.length);
-    console.log(`${bar}\n${header}\n${bar}\n${colors[level] || ''}${msg}${reset} ${comments[level] || ''}`);
+    const style = colors[level] || colors.info;
+    console.log(`${bar}\n${header}\n${bar}\n%c${msg}%c ${comments[level] || ''}`, style, '');
 }
 
 class SpeechSystem {


### PR DESCRIPTION
## Summary
- update `olliePrint` helper in browser scripts to use CSS colors instead of ANSI escapes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68554ff9ad508320a339d31a9fac23d1