### PR TITLE
Centralize Ollama model configuration

### DIFF
--- a/Tools.py
+++ b/Tools.py
@@ -992,9 +992,10 @@ def gist_summarize_source(source: str) -> str:
         ]
         
         response = ollama_manager.chat_concurrent_safe(
-            model=config.GIST_SUMMARY_MODEL,
+            model=config.GIST_OLLAMA_MODEL,
             messages=messages,
-            stream=False
+            stream=False,
+            options=config.LLM_GENERATION_OPTIONS
         )
         
         response_content = response.get('message', {}).get('content', '')

--- a/agents/mad.py
+++ b/agents/mad.py
@@ -164,11 +164,11 @@ Analyze this turn: What new information about Ian or his interests should be sto
             # Get M.A.D. analysis
             response = ollama_manager.chat_concurrent_safe(
                 host=config.OLLAMA_BASE_URL,
-                model=config.DEFAULT_MODEL,
+                model=config.MAD_OLLAMA_MODEL,
                 messages=messages,
                 tools=self.mad_tools,
                 stream=False,
-                options=config.THINKING_MODE_OPTIONS
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             response_message = response.get('message', {})

--- a/agents/scout.py
+++ b/agents/scout.py
@@ -86,9 +86,10 @@ class ScoutAgent:
             )
             
             response = ollama_manager.chat_concurrent_safe(
-                model=config.LLM_DECISION_MODEL,
+                model=config.SCOUT_OLLAMA_MODEL,
                 messages=[{"role": "user", "content": assessment_prompt}],
-                stream=False
+                stream=False,
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             confidence_text = response.get('message', {}).get('content', '0').strip()

--- a/agents/synapse.py
+++ b/agents/synapse.py
@@ -35,12 +35,13 @@ class SynapseAgent:
             print(synthesis_prompt[:2000])
             print("========== [{self.name}] SYNTHESIS PROMPT END =========\n")
             response = ollama_manager.chat_concurrent_safe(
-                model=config.LLM_DECISION_MODEL,
+                model=config.SYNAPSE_OLLAMA_MODEL,
                 messages=[
                     {"role": "system", "content": self._get_system_prompt()},
                     {"role": "user", "content": synthesis_prompt}
                 ],
-                stream=False
+                stream=False,
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             thoughts_content = response.get('message', {}).get('content', '')

--- a/app.py
+++ b/app.py
@@ -513,8 +513,8 @@ def chat_endpoint():
             return jsonify({'error': 'Invalid JSON payload'}), 400
         
         user_message = data.get('message')
-        # Use FRED_MODEL for personality responses, but allow override from client
-        model_name = data.get('model', config.FRED_MODEL)
+        # Use FRED_OLLAMA_MODEL for personality responses, but allow override from client
+        model_name = data.get('model', config.FRED_OLLAMA_MODEL)
         ollama_base_url = data.get('ollama_url', config.OLLAMA_BASE_URL).strip()
         max_tool_iterations = data.get('max_tool_iterations', config.MAX_TOOL_ITERATIONS)
         mute_fred = data.get('mute_fred', False)
@@ -646,7 +646,7 @@ SUBCONSCIOUS PROCESSING RESULTS:
                     messages=messages,
                     tools=AGENT_MANAGEMENT_TOOLS,
                     stream=False,
-                    options=config.THINKING_MODE_OPTIONS
+                    options=config.LLM_GENERATION_OPTIONS
                 )
                 
                 response_message = response.get('message', {})
@@ -791,7 +791,7 @@ The current time is: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
                     model=model_name,
                     messages=messages,
                     stream=True,
-                    options=config.THINKING_MODE_OPTIONS
+                    options=config.LLM_GENERATION_OPTIONS
                 )
                 
                 streaming_response = ""
@@ -899,7 +899,7 @@ def process_transcription(text, from_pi=False):
             # Prepare request data
             request_data = {
                 'message': text,
-                'model': config.FRED_MODEL,  # Use FRED's personality model for voice responses
+                'model': config.FRED_OLLAMA_MODEL,  # Use FRED's personality model for voice responses
                 'mute_fred': False
             }
             

--- a/config.py
+++ b/config.py
@@ -160,79 +160,39 @@ class Config:
     Number: Timeout in seconds (use for production with SLA requirements)
     """
     
-    # --- Language Model Assignments ---
-    # Original models for all system components
-    DEFAULT_MODEL = 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL'
-    """
-    Default language model for system components.
-    Current: Qwen3-30B (high-quality, thinking-capable model)
-    Used by: All system components except FRED's personality
-    """
-    
-    # FRED's personality model (only used for FRED's personality responses)
-    FRED_MODEL = 'hf.co/unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q4_K_XL'
-    """
-    Language model specifically for F.R.E.D.'s personality and general responses.
-    This is the ONLY model that defines F.R.E.D.'s personality and conversational style.
-    Current: Qwen3-30B-A3B-Instruct-2507 (high-quality, instruction-tuned model)
-    Affects: Only FRED's personality and conversational responses
-    """
-    
+    # --- Ollama Model Assignments ---
+    # Centralized model names for all agents
+
+    FRED_OLLAMA_MODEL = 'hf.co/unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q4_K_XL'
+    """Model for F.R.E.D.'s personality and conversation style."""
+
+    GATE_OLLAMA_MODEL = os.getenv('GATE_OLLAMA_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL')
+    MAD_OLLAMA_MODEL = os.getenv('MAD_OLLAMA_MODEL', GATE_OLLAMA_MODEL)
+    SCOUT_OLLAMA_MODEL = os.getenv('SCOUT_OLLAMA_MODEL', GATE_OLLAMA_MODEL)
+    SYNAPSE_OLLAMA_MODEL = os.getenv('SYNAPSE_OLLAMA_MODEL', GATE_OLLAMA_MODEL)
+
+    ARCH_OLLAMA_MODEL = os.getenv('ARCH_OLLAMA_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL')
+    DELVE_OLLAMA_MODEL = os.getenv('DELVE_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+    VET_OLLAMA_MODEL = os.getenv('VET_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+    SAGE_OLLAMA_MODEL = os.getenv('SAGE_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+
+    GIST_OLLAMA_MODEL = os.getenv('GIST_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+    REFLEX_OLLAMA_MODEL = os.getenv('REFLEX_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+    CRAP_OLLAMA_MODEL = os.getenv('CRAP_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+
+    L2_ANALYSIS_OLLAMA_MODEL = os.getenv('L2_ANALYSIS_OLLAMA_MODEL', ARCH_OLLAMA_MODEL)
+    VISION_OLLAMA_MODEL = os.getenv('VISION_OLLAMA_MODEL', 'qwen2.5vl:7b')
+
     EMBED_MODEL = os.getenv('EMBED_MODEL', 'nomic-embed-text')
-    """
-    Text embedding model for semantic search and memory operations.
-    Current: nomic-embed-text (768-dim, good quality/speed balance)
-    Alternative: all-minilm (smaller, faster), sentence-transformers (larger)
-    Affects: Memory search quality and semantic understanding
-    """
-    
     DEFAULT_EMBEDDING_MODEL = os.getenv('DEFAULT_EMBEDDING_MODEL', 'nomic-embed-text')
-    """
-    Default embedding model for agenda system and general embedding tasks.
-    Should match EMBED_MODEL for consistency across the system.
-    """
-    
-    LLM_DECISION_MODEL = os.getenv('LLM_DECISION_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL')
-    THINKING_MODEL = DEFAULT_MODEL
-    """
-    Model for complex decision-making and reasoning tasks.
-    Should be high-quality model with strong reasoning capabilities.
-    Used for: Agent routing, complex analysis, strategic decisions
-    """
-    
-    # --- Consolidated Research Model ---
-    CONSOLIDATED_MODEL = os.getenv('CONSOLIDATED_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL')
-    """
-    Unified model for all research agents (ARCH, DELVE, VET, SAGE) to prevent multiple model loads.
-    Using same model with different system prompts for different agent personalities.
-    Memory optimization: Single model instance shared across all research components.
-    """
-    
-    # --- AI Reasoning Parameters ---
-    THINKING_MODE_OPTIONS = {
-        "temperature": 0.6, 
-        "min_p": 0.0, 
-        "top_p": 0.95, 
-        "top_k": 20,
-        "num_ctx": 4096,
-        "num_thread": 16
+
+    # --- Generation Options ---
+    LLM_GENERATION_OPTIONS = {
+        'temperature': 0.6,
+        'top_p': 0.95,
+        'top_k': 20,
+        'num_ctx': 4096,  # Context window
     }
-    """
-    Optimized parameters for Qwen3 thinking mode.
-    - temperature: 0.6 (balanced creativity/consistency)
-    - min_p: 0.0 (no minimum probability threshold)
-    - top_p: 0.95 (nucleus sampling for quality)
-    - top_k: 20 (limit consideration to top 20 tokens)
-    Source: Official Qwen3 documentation recommendations
-    """
-    
-    # --- Specialized Model Assignments ---
-    CRAP_MODEL = 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL'
-    """
-    Model for C.R.A.P. (Context Retrieval for Augmented Prompts) memory analysis.
-    Q4_K_M quantization: Slightly compressed for faster memory operations
-    while maintaining quality for context retrieval tasks.
-    """
     
     # ============================================================================
     # 3. AUDIO PROCESSING CONFIGURATION
@@ -834,12 +794,7 @@ class Config:
     Used by Phase 4 quality assessment system for comprehensive confidence scoring.
     """
     
-    # --- Specialized Agent Models ---
-    GIST_SUMMARY_MODEL = "hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL"
-    """Model for G.I.S.T. (Global Information Sanitation Tool) content filtering."""
-    
-    REFLEX_MODEL = "hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL"
-    """Model for R.E.F.L.E.X. (Research Executive For Learning EXtraction) processing."""
+
     
     # ============================================================================
     # 7. AGENT SYSTEM CONFIGURATION
@@ -907,9 +862,6 @@ class Config:
     # --- Vision Processing Configuration ---
     VISION_PROCESSING_INTERVAL = 10
     """Time interval in seconds between visual processing cycles."""
-    
-    VISION_MODEL = "qwen2.5vl:7b"
-    """Multimodal model for analyzing visual input from smart glasses."""
     
     VISION_ENABLED = True
     """Enable/disable visual processing system."""
@@ -1019,13 +971,13 @@ class Config:
 
 
 # Global Ollama connection manager instance
-ollama_manager = OllamaConnectionManager(Config.OLLAMA_BASE_URL, Config.THINKING_MODE_OPTIONS)
+ollama_manager = OllamaConnectionManager(Config.OLLAMA_BASE_URL, Config.LLM_GENERATION_OPTIONS)
 
 # Global config instance
 config = Config()
 
 # Make CRAP_MODEL available for direct import
-CRAP_MODEL = Config.CRAP_MODEL
+CRAP_MODEL = Config.CRAP_OLLAMA_MODEL
 
 # Re-attach prompts and tools to the Config class to maintain the config.VARIABLE access pattern
 config.FRED_SYSTEM_PROMPT = FRED_SYSTEM_PROMPT
@@ -1049,7 +1001,7 @@ config.VISION_SYSTEM_PROMPT = VISION_SYSTEM_PROMPT
 config.VISION_USER_PROMPT = VISION_USER_PROMPT
 config.CRAP_SYSTEM_PROMPT = CRAP_SYSTEM_PROMPT
 config.CRAP_USER_PROMPT = CRAP_USER_PROMPT
-config.CRAP_MODEL = Config.CRAP_MODEL
+config.CRAP_MODEL = Config.CRAP_OLLAMA_MODEL
 
 config.MEMORY_TOOLS = MEMORY_TOOLS
 config.CRAP_TOOLS = CRAP_TOOLS

--- a/memory/L2_memory.py
+++ b/memory/L2_memory.py
@@ -180,10 +180,11 @@ def analyze_conversation_chunk(messages: List[Dict], turn_start: int, turn_end: 
         ]
 
         response = ollama_manager.chat_concurrent_safe(
-            model=config.L2_ANALYSIS_MODEL,
+            model=config.L2_ANALYSIS_OLLAMA_MODEL,
             messages=chat_messages,
             stream=False,
-            format="json"
+            format="json",
+            options=config.LLM_GENERATION_OPTIONS
         )
         
         response_text = response.get('message', {}).get('content', '').strip()

--- a/memory/L3_memory.py
+++ b/memory/L3_memory.py
@@ -21,8 +21,8 @@ from memory.supersession_helpers import (
 # --- Configuration ---
 # Set default path inside the memory folder
 DB_FILE = os.path.join('memory', 'memory.db')  # Default that can be overridden
-EMBED_MODEL = os.getenv('EMBED_MODEL', 'nomic-embed-text')
-LLM_DECISION_MODEL = os.getenv('LLM_DECISION_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL') # As requested
+EMBED_MODEL = config.EMBED_MODEL
+LLM_DECISION_MODEL = config.GATE_OLLAMA_MODEL
 EMBEDDING_DIM = 768 # As specified for nomic-embed-text
 
 # Use centralized Ollama connection manager for all L3 operations
@@ -153,7 +153,8 @@ def call_ollama_generate(prompt, model=LLM_DECISION_MODEL):
             model=model,
             messages=messages,
             stream=False,
-            format="json" # Explicitly request JSON format
+            format="json",  # Explicitly request JSON format
+            options=config.LLM_GENERATION_OPTIONS
         )
         
         response_content = response.get('message', {}).get('content', '')
@@ -348,7 +349,7 @@ If no clear relationship exists, use null for relationship_type and low confiden
             model=LLM_DECISION_MODEL,
             messages=[{"role": "user", "content": enhanced_prompt}],
             stream=False,
-            options={"temperature": 0.1}  # Low temperature for consistent analysis
+            options=config.LLM_GENERATION_OPTIONS
         )
         
         response_text = response.get('message', {}).get('content', '').strip()

--- a/memory/agenda_system.py
+++ b/memory/agenda_system.py
@@ -49,9 +49,10 @@ def generate_fred_research_summary(original_task: str, research_findings: str) -
         ]
         
         response = ollama_manager.chat_concurrent_safe(
-            model=config.REFLEX_MODEL,
+            model=config.REFLEX_OLLAMA_MODEL,
             messages=messages,
-            stream=False
+            stream=False,
+            options=config.LLM_GENERATION_OPTIONS
         )
         
         fred_summary = response.get('message', {}).get('content', '').strip()

--- a/memory/arch_delve_research.py
+++ b/memory/arch_delve_research.py
@@ -22,7 +22,7 @@ from ollie_print import olliePrint_simple
 # All agents (ARCH, DELVE, SAGE, VET) use the same model to prevent multiple model loads
 # Model personality is defined by system prompts, not different model instances
 # Import unified model from centralized config
-CONSOLIDATED_MODEL = config.CONSOLIDATED_MODEL
+CONSOLIDATED_MODEL = config.ARCH_OLLAMA_MODEL
 
 # Use same response handling pattern as app.py (which works)
 
@@ -1293,7 +1293,7 @@ def run_enhanced_arch_iteration(session: ArchDelveState, enable_streaming: bool 
                 messages=messages,
                 tools=arch_tools,
                 stream=True,
-                options=config.THINKING_MODE_OPTIONS
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             raw_content = ""
@@ -1378,7 +1378,7 @@ def run_enhanced_arch_iteration(session: ArchDelveState, enable_streaming: bool 
                 messages=messages,
                 tools=arch_tools,
                 stream=False,
-                options=config.THINKING_MODE_OPTIONS
+                options=config.LLM_GENERATION_OPTIONS
             )
         
         call_duration = time.time() - start_time
@@ -1497,7 +1497,7 @@ def run_fresh_delve_iteration(arch_instruction: str, task_id: str, iteration_cou
                     tools=delve_tools,
                     stream=True,
                     format="json",
-                    options=config.THINKING_MODE_OPTIONS
+                    options=config.LLM_GENERATION_OPTIONS
                 )
                 
                 raw_content = ""
@@ -1585,7 +1585,7 @@ def run_fresh_delve_iteration(arch_instruction: str, task_id: str, iteration_cou
                 tools=delve_tools,
                 stream=False,
                 format="json",
-                options=config.THINKING_MODE_OPTIONS
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             # Extract content and tool calls using app.py pattern
@@ -1774,7 +1774,7 @@ def run_fresh_vet_iteration(delve_data: dict, arch_instruction: str, task_id: st
                 model=CONSOLIDATED_MODEL,
                 messages=messages,
                 stream=True,
-                options=config.THINKING_MODE_OPTIONS
+                options=config.LLM_GENERATION_OPTIONS
             )
             
             raw_verified_report = ""
@@ -1852,7 +1852,7 @@ def run_fresh_vet_iteration(delve_data: dict, arch_instruction: str, task_id: st
             model=CONSOLIDATED_MODEL,
             messages=messages,
             stream=False,
-            options=config.THINKING_MODE_OPTIONS
+            options=config.LLM_GENERATION_OPTIONS
         )
 
         # Extract content using app.py pattern

--- a/memory/gate.py
+++ b/memory/gate.py
@@ -89,9 +89,9 @@ def _get_routing_flags(user_message: str, recent_history: list) -> dict:
         ]
 
         response = ollama_manager.chat_concurrent_safe(
-            model=config.LLM_DECISION_MODEL,
+            model=config.GATE_OLLAMA_MODEL,
             messages=messages,
-            options=config.THINKING_MODE_OPTIONS,
+            options=config.LLM_GENERATION_OPTIONS,
             format="json"  # Ensure JSON output
         )
 

--- a/ollama_chat.py
+++ b/ollama_chat.py
@@ -12,14 +12,14 @@ except ImportError:
     print("Please run this script from the root of your F.R.E.D. project directory.")
     sys.exit(1)
 
-# The model and its parameters (num_gpu, num_ctx, etc.) are now loaded from config
+# The model and its parameters are loaded from config
 MODEL_NAME = "hf.co/unsloth/Qwen3-30B-A3B-GGUF:Q3_K_XL"
 
 # --- Main Chat Logic ---
 def main():
     """Main function to run the terminal chat client."""
     print(f"--- Starting chat with '{MODEL_NAME}' ---")
-    print(f"(Parameters: num_gpu={config.THINKING_MODE_OPTIONS.get('num_gpu')}, num_ctx={config.THINKING_MODE_OPTIONS.get('num_ctx')})")
+    print(f"(Parameters: num_ctx={config.LLM_GENERATION_OPTIONS.get('num_ctx')})")
     print("Type 'quit', 'exit', or press Ctrl+C to end the chat.")
     print("--------------------------------------------------")
 

--- a/prompts.py
+++ b/prompts.py
@@ -775,3 +775,7 @@ TOOL USAGE:
 Keep analysis brief and focused. Only use tools when you identify genuinely new information.
 </ToolUsageGuidelines>
 """
+
+# Placeholder prompts for legacy components
+CRAP_SYSTEM_PROMPT = ""
+CRAP_USER_PROMPT = ""

--- a/tests/test_gate_integration.py
+++ b/tests/test_gate_integration.py
@@ -27,7 +27,7 @@ class TestGateIntegration(unittest.TestCase):
     def setUpClass(cls):
         """Preload model once and create a shared dispatcher to minimize server workers."""
         from config import config, ollama_manager
-        ollama_manager.preload_model(config.DEFAULT_MODEL)
+        ollama_manager.preload_model(config.GATE_OLLAMA_MODEL)
         cls.dispatcher = AgentDispatcher()
         # Single MagicMock reused—return value string distinguishes tests for logging
         cls.dispatcher.dispatch_agents = MagicMock(return_value="Dispatcher reused by setUpClass")

--- a/tests/test_mad_integration.py
+++ b/tests/test_mad_integration.py
@@ -27,7 +27,7 @@ class TestMadIntegration(unittest.TestCase):
     def setUpClass(cls):
         """Preload the model once and prepare shared MADAgent instance."""
         from config import config
-        ollama_manager.preload_model(config.DEFAULT_MODEL)
+        ollama_manager.preload_model(config.MAD_OLLAMA_MODEL)
 
         # Patch the actual memory-writing Tools so we don't write to a real database
         cls.add_memory_patcher = patch('Tools.tool_add_memory', MagicMock(return_value={"success": True, "id": 1}))

--- a/vision_service.py
+++ b/vision_service.py
@@ -14,7 +14,7 @@ apply_theme()
 
 class VisionService:
     def __init__(self):
-        self.model = config.VISION_MODEL
+        self.model = config.VISION_OLLAMA_MODEL
         
         # Initialize Qwen dimensions - optimized for Pi camera native resolution
         self.qwen_max_pixels = 3584 * 3584  # 12.8 MP - Qwen 2.5-VL 7B limit

--- a/webrtc_server.py
+++ b/webrtc_server.py
@@ -134,10 +134,10 @@ async def offer(request):
                 if not text or not text.strip():
                     return
 
-                # Prepare chat request for main server - use FRED_MODEL for consistent personality
+                # Prepare chat request for main server - use FRED_OLLAMA_MODEL for consistent personality
                 payload = {
                     "message": text,
-                    "model": config.FRED_MODEL,  # Use FRED's personality model for Pi transcriptions
+                    "model": config.FRED_OLLAMA_MODEL,  # Use FRED's personality model for Pi transcriptions
                     "mute_fred": False,
                     "from_pi_glasses": True,
                 }


### PR DESCRIPTION
## Summary
- add new `LLM_GENERATION_OPTIONS` and per‑agent model names
- refactor codebase to use centralized configuration for model names and options
- update tests to preload models via new variables
- add placeholder CRAP prompts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'duckduckgo_search')*

------
https://chatgpt.com/codex/tasks/task_e_688a2dbd03e88320af4765cf9befb424