### PR TITLE
Remove thinking content retention

### DIFF
--- a/memory/gate.py
+++ b/memory/gate.py
@@ -6,6 +6,7 @@ from config import config, ollama_manager
 from utils import strip_think_tags
 
 from agents.dispatcher import AgentDispatcher
+import memory.L2_memory as L2
 
 def run_gate_analysis(user_message: str, conversation_history: list, agent_dispatcher: AgentDispatcher, visual_context: str = "") -> str:
     """


### PR DESCRIPTION
## Summary
- avoid persisting assistant thinking in `FREDState` history
- simplify MAD context preparation and history
- drop thinking storage and truncation logic from research pipeline
- remove thinking stream buffers for research

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_688a8c2ef7fc8320af48cc1bd7cc86b9