### PR TITLE
Fix Ollama manager and embeddings

### DIFF
--- a/config.py
+++ b/config.py
@@ -981,7 +981,8 @@ class Config:
 
 
 # Global Ollama connection manager instance
-ollama_manager = OllamaConnectionManager(Config.OLLAMA_BASE_URL, Config.LLM_GENERATION_OPTIONS)
+ollama_manager_instance = OllamaConnectionManager(Config.OLLAMA_BASE_URL, Config.LLM_GENERATION_OPTIONS)
+ollama_manager = ollama_manager_instance
 
 # Global config instance
 config = Config()

--- a/memory/L2_memory.py
+++ b/memory/L2_memory.py
@@ -12,7 +12,13 @@ import threading
 import uuid
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Tuple
-from sklearn.metrics.pairwise import cosine_similarity
+try:
+    from sklearn.metrics.pairwise import cosine_similarity
+except Exception:  # Fallback if sklearn is unavailable
+    def cosine_similarity(a, b):
+        a = np.array(a)
+        b = np.array(b)
+        return np.dot(a, b.T) / (np.linalg.norm(a, axis=1)[:, None] * np.linalg.norm(b, axis=1))
 from config import config, ollama_manager
 from ollie_print import olliePrint_simple
 

--- a/web_search_core.py
+++ b/web_search_core.py
@@ -12,11 +12,12 @@ import trafilatura
 from datetime import datetime
 
 import config
-from memory.ollama_manager import OllamaManager
+from ollama_manager import OllamaConnectionManager
 from Tools import search_brave, search_searchapi  # Import existing search functions
 
 # Initialize Ollama manager
-ollama_manager = OllamaManager()
+ollama_manager_instance = OllamaConnectionManager(config.OLLAMA_BASE_URL, config.LLM_GENERATION_OPTIONS)
+ollama_manager = ollama_manager_instance
 
 # Domain blacklist for spam/ad filtering
 SPAM_DOMAINS = {
@@ -341,8 +342,8 @@ def calculate_relevance_score(query: str, title: str) -> float:
     """
     try:
         # Get embeddings for both query and title
-        query_embedding = ollama_manager.get_embeddings(query, config.EMBED_MODEL)
-        title_embedding = ollama_manager.get_embeddings(title, config.EMBED_MODEL)
+        query_embedding = ollama_manager.embeddings(model=config.EMBED_MODEL, prompt=query)
+        title_embedding = ollama_manager.embeddings(model=config.EMBED_MODEL, prompt=title)
         
         if not query_embedding or not title_embedding:
             return 0.0


### PR DESCRIPTION
## Summary
- import OllamaConnectionManager in `web_search_core.py`
- instantiate manager with consistent variable names
- change `get_embeddings` calls to `embeddings`
- expose `ollama_manager_instance` in config
- provide fallback cosine similarity when sklearn is unavailable

## Testing
- `pytest -q` *(fails: Failed to connect to Ollama)*

------
https://chatgpt.com/codex/tasks/task_e_688d4cfc90408320ada94274c92681e8