### PR TITLE
Add INSTRUCT_OLLAMA_MODEL config option

### DIFF
--- a/config.py
+++ b/config.py
@@ -166,6 +166,9 @@ class Config:
     FRED_OLLAMA_MODEL = 'hf.co/unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Q4_K_XL'
     """Model for F.R.E.D.'s personality and conversation style."""
 
+    INSTRUCT_OLLAMA_MODEL = os.getenv('INSTRUCT_OLLAMA_MODEL', FRED_OLLAMA_MODEL)
+    """General instruction-following model used for utility tasks."""
+
     GATE_OLLAMA_MODEL = os.getenv('GATE_OLLAMA_MODEL', 'hf.co/unsloth/Qwen3-30B-A3B-Thinking-2507-GGUF:Q4_K_XL')
     MAD_OLLAMA_MODEL = os.getenv('MAD_OLLAMA_MODEL', GATE_OLLAMA_MODEL)
     SYNAPSE_OLLAMA_MODEL = os.getenv('SYNAPSE_OLLAMA_MODEL', GATE_OLLAMA_MODEL)


### PR DESCRIPTION
## Summary
- add `INSTRUCT_OLLAMA_MODEL` configuration variable
- reference new variable from `web_search_core`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_688d4cfe76f48320bded042f5bfb7783