### PR TITLE
Refactor tests for web_search_strategy flags

### DIFF
--- a/FRED_V2_Comprehensive_Analysis.md
+++ b/FRED_V2_Comprehensive_Analysis.md
@@ -143,7 +143,7 @@ F.R.E.D.'s ability to process complex queries and maintain robust contextual awa
 - **Role:** G.A.T.E. acts as the central routing component of F.R.E.D.'s cognitive architecture. Its sole purpose is to analyze incoming user queries and recent conversational context, then determine which specialized agents need to be activated to gather the necessary information. It replaces older, less sophisticated triage functionalities.
 - **Process:**
     - G.A.T.E. receives the user's message, the L2 episodic context (`memory/L2_memory.py`), and a truncated history of the most recent conversation turns (without F.R.E.D.'s internal thinking).
-    - It uses an LLM (governed by `GATE_SYSTEM_PROMPT`) to generate a JSON object containing boolean routing flags (e.g., `needs_memory`, `needs_web_search`, `needs_deep_research`, `needs_pi_tools`, `needs_reminders`).
+    - It uses an LLM (governed by `GATE_SYSTEM_PROMPT`) to generate a JSON object containing routing flags (e.g., `needs_memory`, `web_search_strategy`, `needs_deep_research`, `needs_pi_tools`, `needs_reminders`).
     - **L2 Context Bypass Protocol:** G.A.T.E. can bypass memory agents if the provided L2 context contains sufficient information to fully answer the user's query.
 - **Output:** The routing flags are then passed to the `AgentDispatcher` (`agents/dispatcher.py`), which orchestrates the execution of the flagged agents.
 
@@ -158,7 +158,7 @@ F.R.E.D.'s ability to process complex queries and maintain robust contextual awa
 
 #### S.C.O.U.T. (Search & Confidence Optimization Utility Tool) - The Web Scout (`agents/scout.py`)
 
-- **Role:** S.C.O.U.T. is F.R.E.D.'s rapid reconnaissance specialist, activated by the `AgentDispatcher` when G.A.T.E.'s routing flags indicate `needs_web_search`. Its mission is to perform quick web searches and assess the confidence level of its findings.
+- **Role:** S.C.O.U.T. is F.R.E.D.'s rapid reconnaissance specialist, activated when `web_search_strategy.needed` is true. Its mission is to perform quick web searches and assess the confidence level of its findings.
 - **Process:**
     - It uses web search tools (e.g., `search_general`, `search_news`) to find relevant information.
     - It assesses the completeness, source reliability, recency, and relevance of the search results.

--- a/agents/dispatcher.py
+++ b/agents/dispatcher.py
@@ -42,7 +42,7 @@ class AgentDispatcher:
         Dispatch agents based on G.A.T.E. routing flags and return synthesized NEURAL PROCESSING CORE.
         
         Args:
-            routing_flags: Dict with needs_memory, needs_web_search, needs_deep_research, needs_pi_tools, needs_reminders
+            routing_flags: Dict with needs_memory, web_search_strategy, needs_deep_research, needs_pi_tools, needs_reminders
             user_message: Current user message
             conversation_history: Full conversation history
             visual_context: Visual context from Pi glasses if available

--- a/prompts.py
+++ b/prompts.py
@@ -169,7 +169,7 @@ GATE_USER_PROMPT = """<Header>
 </Context>
 
 <Directive>
-**Directive**: Analyze the query and context. Return ONLY a JSON object with routing flags: needs_memory, needs_web_search, needs_deep_research, needs_pi_tools, needs_reminders.
+**Directive**: Analyze the query and context. Return ONLY a JSON object with routing flags: needs_memory, web_search_strategy, needs_deep_research, needs_pi_tools, needs_reminders.
 </Directive>"""
 
 # --- Enhanced Research System Prompts ---

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -13,6 +13,7 @@ sys.modules['requests'] = MagicMock()
 sys.modules['trafilatura'] = MagicMock()
 sys.modules['duckdb'] = MagicMock()
 sys.modules['numpy'] = MagicMock()
+sys.modules['memory.L2_memory'] = MagicMock()
 
 # Now, import the modules to be tested
 from memory import gate
@@ -29,7 +30,14 @@ class TestGateAgent(unittest.TestCase):
         # Arrange
         mock_dispatcher = MagicMock(spec=AgentDispatcher)
         mock_dispatcher.dispatch_agents.return_value = "Dispatcher processed memory task."
-        expected_flags = {"needs_memory": True, "needs_web_search": False}
+        expected_flags = {
+            "needs_memory": True,
+            "web_search_strategy": {
+                "needed": False,
+                "search_priority": "quick",
+                "search_query": ""
+            }
+        }
         mock_ollama.return_value = {'message': {'content': json.dumps(expected_flags)}}
         mock_l2_query.return_value = "No relevant context."
 
@@ -41,7 +49,10 @@ class TestGateAgent(unittest.TestCase):
         call_kwargs = mock_dispatcher.dispatch_agents.call_args.kwargs
         self.assertIn('routing_flags', call_kwargs)
         self.assertEqual(call_kwargs['routing_flags']['needs_memory'], True)
-        self.assertEqual(call_kwargs['routing_flags']['needs_web_search'], False)
+        self.assertEqual(
+            call_kwargs['routing_flags']['web_search_strategy']['needed'],
+            False
+        )
         print("PASSED: Correctly routed to memory agent.")
 
     @patch('memory.gate.L2.query_l2_context')
@@ -52,7 +63,15 @@ class TestGateAgent(unittest.TestCase):
         # Arrange
         mock_dispatcher = MagicMock(spec=AgentDispatcher)
         mock_dispatcher.dispatch_agents.return_value = "Dispatcher processed multi-agent task."
-        expected_flags = {"needs_memory": True, "needs_web_search": True, "needs_pi_tools": False}
+        expected_flags = {
+            "needs_memory": True,
+            "needs_pi_tools": False,
+            "web_search_strategy": {
+                "needed": True,
+                "search_priority": "quick",
+                "search_query": ""
+            }
+        }
         mock_ollama.return_value = {'message': {'content': json.dumps(expected_flags)}}
         mock_l2_query.return_value = "User mentioned AI hardware."
 
@@ -64,7 +83,10 @@ class TestGateAgent(unittest.TestCase):
         call_kwargs = mock_dispatcher.dispatch_agents.call_args.kwargs
         self.assertIn('routing_flags', call_kwargs)
         self.assertEqual(call_kwargs['routing_flags']['needs_memory'], True)
-        self.assertEqual(call_kwargs['routing_flags']['needs_web_search'], True)
+        self.assertEqual(
+            call_kwargs['routing_flags']['web_search_strategy']['needed'],
+            True
+        )
         self.assertEqual(call_kwargs['routing_flags']['needs_pi_tools'], False)
         print("PASSED: Correctly routed to multiple agents.")
 

--- a/tests/test_gate_integration.py
+++ b/tests/test_gate_integration.py
@@ -68,8 +68,10 @@ class TestGateIntegration(unittest.TestCase):
         print(f"--> Routing flags from real model: {routing_flags}")
 
         # The primary assertion: did the model correctly flag a web search?
-        self.assertTrue(routing_flags.get('needs_web_search', False), 
-                        "The real model failed to flag 'needs_web_search' as True.")
+        self.assertTrue(
+            routing_flags.get('web_search_strategy', {}).get('needed', False),
+            "The real model failed to flag 'web_search_strategy.needed' as True."
+        )
 
         print("\nIntegration Test Passed: The real AI model correctly triggered a web search route.")
         print(f"Final content received: {final_content}")
@@ -86,7 +88,10 @@ class TestGateIntegration(unittest.TestCase):
         self.assertTrue(agent_dispatcher.dispatch_agents.called, "Dispatcher not called for implicit web search")
         routing_flags = agent_dispatcher.dispatch_agents.call_args.kwargs['routing_flags']
         print(f"--> Routing flags (implicit web search): {routing_flags}")
-        self.assertTrue(routing_flags.get('needs_web_search', False), "Model failed to flag needs_web_search for implicit query")
+        self.assertTrue(
+            routing_flags.get('web_search_strategy', {}).get('needed', False),
+            "Model failed to flag web_search_strategy for implicit query"
+        )
 
     @patch('memory.gate.L2.query_l2_context')
     def test_gate_analysis_memory_only_implicit(self, mock_l2_query):


### PR DESCRIPTION
## Summary
- update prompts and dispatcher docstrings to mention `web_search_strategy`
- adjust comprehensive analysis doc to describe the new routing flag
- patch tests to expect the `web_search_strategy` object
- mock memory.L2 imports in unit tests

## Testing
- `pytest tests/test_gate.py tests/test_gate_integration.py -q` *(fails: real Ollama model connection required)*

------
https://chatgpt.com/codex/tasks/task_e_688d4e24d8d48320a0f88937c171beb3