### PR TITLE
Optimize trafilatura usage

### DIFF
--- a/Tools.py
+++ b/Tools.py
@@ -1022,12 +1022,20 @@ def tool_read_webpage(url: str) -> dict:
             return {"success": False, "error": f"{error_prefix} Reason: PDF extraction failed. Details: {e}"}
     else:
         try:
-            downloaded = fetch_url(url)
-            if not downloaded:
-                return {"success": False, "error": f"{error_prefix} Reason: Failed to download webpage content."}
-            content = extract(downloaded, include_links=False)
+            import requests
+            response = requests.get(url)
+            response.raise_for_status()
+
+            # Try extracting directly from the response
+            content = extract(response.text, include_links=False)
             if not content:
-                return {"success": False, "error": f"{error_prefix} Reason: No main content could be extracted from the webpage."}
+                downloaded = fetch_url(url)
+                if not downloaded:
+                    return {"success": False, "error": f"{error_prefix} Reason: Failed to download webpage content."}
+                content = extract(downloaded, include_links=False)
+                if not content:
+                    return {"success": False, "error": f"{error_prefix} Reason: No main content could be extracted from the webpage."}
+
             return {"success": True, "url": url, "content": gist_summarize_source(content), "links_found": len(content.split())}
         except Exception as e:
             return {"success": False, "error": f"{error_prefix} Reason: General error during webpage processing. Details: {e}"}

--- a/web_search_core.py
+++ b/web_search_core.py
@@ -135,19 +135,20 @@ def extract_page_content(url: str) -> Optional[Dict[str, str]]:
         
         response = requests.get(url, headers=headers, timeout=10)
         response.raise_for_status()
-        
-        # Use trafilatura for content extraction
-        downloaded = trafilatura.fetch_url(url)
-        if not downloaded:
-            return None
-            
-        # Extract main content
-        content = trafilatura.extract(downloaded, include_comments=False, include_tables=True)
+
+        html = response.text
+
+        # Try extracting from the downloaded HTML first
+        content = trafilatura.extract(html, include_comments=False, include_tables=True)
+        metadata = trafilatura.extract_metadata(html) if content else None
         if not content:
-            return None
-        
-        # Extract metadata
-        metadata = trafilatura.extract_metadata(downloaded)
+            downloaded = trafilatura.fetch_url(url)
+            if not downloaded:
+                return None
+            content = trafilatura.extract(downloaded, include_comments=False, include_tables=True)
+            if not content:
+                return None
+            metadata = trafilatura.extract_metadata(downloaded)
         
         # Build result dictionary
         result = {


### PR DESCRIPTION
## Summary
- extract webpage text using requests response first
- only call `trafilatura.fetch_url` if needed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'json5', ImportError: cannot import name '__version__' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_688d4e2f3c6883208a0d3b23408ceebe