### PR TITLE
Use relevance scores in search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ with:
 ```bash
 python client.py --server http://<fred-ip>:8080
 ```
+
+## Intelligent Search Scoring
+
+`web_search_core.intelligent_search` ranks gathered links by a semantic
+relevance score.  `calculate_relevance_score` embeds the query and each link
+title using the configured model and computes their cosine similarity.
+Links with higher scores are assumed more related to the query and the top
+results are selected directly—no link-analysis LLM call is made.


### PR DESCRIPTION
## Summary
- rank gathered links by embedding similarity only
- update docs for search scoring
- remove sklearn dependency from L2 memory

## Testing
- `pytest tests/test_gate.py -q`
- `pytest -q` *(fails: missing Ollama connection)*

------
https://chatgpt.com/codex/tasks/task_e_688d4cfa747883209b03f7b4e364f18d