### PR TITLE
Switch tests to web_search_strategy

### DIFF
--- a/FRED_V2_Comprehensive_Analysis.md
+++ b/FRED_V2_Comprehensive_Analysis.md
@@ -143,7 +143,7 @@ F.R.E.D.'s ability to process complex queries and maintain robust contextual awa
 - **Role:** G.A.T.E. acts as the central routing component of F.R.E.D.'s cognitive architecture. Its sole purpose is to analyze incoming user queries and recent conversational context, then determine which specialized agents need to be activated to gather the necessary information. It replaces older, less sophisticated triage functionalities.
 - **Process:**
     - G.A.T.E. receives the user's message, the L2 episodic context (`memory/L2_memory.py`), and a truncated history of the most recent conversation turns (without F.R.E.D.'s internal thinking).
-    - It uses an LLM (governed by `GATE_SYSTEM_PROMPT`) to generate a JSON object containing boolean routing flags (e.g., `needs_memory`, `needs_web_search`, `needs_deep_research`, `needs_pi_tools`, `needs_reminders`).
+    - It uses an LLM (governed by `GATE_SYSTEM_PROMPT`) to generate a JSON object containing routing flags (e.g., `needs_memory`, `web_search_strategy`, `needs_deep_research`, `needs_pi_tools`, `needs_reminders`).
     - **L2 Context Bypass Protocol:** G.A.T.E. can bypass memory agents if the provided L2 context contains sufficient information to fully answer the user's query.
 - **Output:** The routing flags are then passed to the `AgentDispatcher` (`agents/dispatcher.py`), which orchestrates the execution of the flagged agents.
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -49,6 +49,8 @@ class TestGateAgent(unittest.TestCase):
         self.assertIn('routing_flags', call_kwargs)
         self.assertEqual(call_kwargs['routing_flags']['needs_memory'], True)
         self.assertEqual(call_kwargs['routing_flags']['web_search_strategy']['needed'], False)
+        self.assertIn('search_priority', call_kwargs['routing_flags']['web_search_strategy'])
+        self.assertIn('search_query', call_kwargs['routing_flags']['web_search_strategy'])
         print("PASSED: Correctly routed to memory agent.")
 
     @patch('memory.gate.L2.query_l2_context')
@@ -76,6 +78,8 @@ class TestGateAgent(unittest.TestCase):
         self.assertIn('routing_flags', call_kwargs)
         self.assertEqual(call_kwargs['routing_flags']['needs_memory'], True)
         self.assertEqual(call_kwargs['routing_flags']['web_search_strategy']['needed'], True)
+        self.assertIn('search_priority', call_kwargs['routing_flags']['web_search_strategy'])
+        self.assertIn('search_query', call_kwargs['routing_flags']['web_search_strategy'])
         self.assertEqual(call_kwargs['routing_flags']['needs_pi_tools'], False)
         print("PASSED: Correctly routed to multiple agents.")
 


### PR DESCRIPTION
## Summary
- check new search_priority and search_query keys in tests
- document web_search_strategy flag in architecture overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d57c198408320b5584f106b2d84fe