### PR TITLE
Improve link ranking with embedding-based scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ with:
 ```bash
 python client.py --server http://<fred-ip>:8080
 ```
+
+## Intelligent Search
+
+FRED-V2 performs web searches using `intelligent_search`, which ranks result
+links purely by semantic similarity between your query and the page title. The
+relevance score is computed via embeddings in `calculate_relevance_score` and
+the top results are fetched without any additional LLM analysis.

--- a/web_search_core.py
+++ b/web_search_core.py
@@ -173,14 +173,19 @@ def extract_page_content(url: str) -> Optional[Dict[str, str]]:
 
 
 def intelligent_search(query: str, search_priority: str = "quick", mode: str = "auto") -> Dict:
-    """
-    LLM-based intelligent search with flexible modes.
-    
+    """Perform a web search and rank links by semantic similarity.
+
+    The function gathers links using the configured search engines and then
+    ranks them using :func:`calculate_relevance_score`.  Links with the highest
+    semantic similarity between the query and the page title are selected for
+    content extraction.  This avoids the previous LLM-based link analysis and
+    relies solely on embedding similarity.
+
     Args:
         query: Search query string
-        search_priority: "quick" or "thorough" 
-        mode: "links_only", "auto", or "deep"
-        
+        search_priority: ``"quick"`` or ``"thorough"``
+        mode: ``"links_only"``, ``"auto"``, or ``"deep"``
+
     Returns:
         Dictionary with search results and analysis
     """
@@ -196,34 +201,17 @@ def intelligent_search(query: str, search_priority: str = "quick", mode: str = "
                 'summary': "Links only mode - no content extracted"
             }
         
-        # Step 2: Use LLM to determine which links to extract content from
-        link_analysis_prompt = f"""
-        Analyze these search result links for the query: "{query}"
-        
-        Links:
-        {json.dumps(links, indent=2)}
-        
-        Select the 3 most promising links that are likely to contain relevant, authoritative information.
-        Consider: relevance to query, domain authority, title quality, description relevance.
-        
-        Respond with JSON: {{"selected_urls": ["url1", "url2", "url3"], "reasoning": "brief explanation"}}
-        """
-        
-        messages = [{"role": "user", "content": link_analysis_prompt}]
-        
-        analysis_response = ollama_manager.chat_concurrent_safe(
-            model=config.INSTRUCT_OLLAMA_MODEL,
-            messages=messages,
-            options=config.LLM_GENERATION_OPTIONS,
-            format="json"
-        )
-        
-        try:
-            analysis = json.loads(analysis_response)
-            selected_urls = analysis.get('selected_urls', [url['url'] for url in links[:3]])
-        except:
-            # Fallback: use first 3 URLs
-            selected_urls = [link['url'] for link in links[:3]]
+        # Step 2: Rank links using semantic similarity
+        scored_links = []
+        for link in links:
+            score = calculate_relevance_score(query, link.get('title', ''))
+            link_with_score = link.copy()
+            link_with_score['score'] = score
+            scored_links.append(link_with_score)
+
+        scored_links.sort(key=lambda x: x['score'], reverse=True)
+        links = scored_links
+        selected_urls = [item['url'] for item in links[:3]]
         
         # Step 3: Extract content from selected URLs
         extracted_content = []


### PR DESCRIPTION
## Summary
- rank search links with semantic similarity instead of LLM analysis
- explain scoring logic in `intelligent_search`
- document the new approach in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5c4f810c8320bee9d9ee498a9d55