### PR TITLE
Route LLM output through color logger

### DIFF
--- a/agents/mad.py
+++ b/agents/mad.py
@@ -72,13 +72,13 @@ Analyze this turn: What new information about Ian or his interests should be sto
         """Execute M.A.D. tool calls (add_memory and add_memory_with_observations)."""
         results = []
         
-        print(f"\n--- M.A.D. Tool Calls ({len(tool_calls)}) ---")
+        olliePrint_simple(f"--- M.A.D. Tool Calls ({len(tool_calls)}) ---", level='debug')
         for tool_call in tool_calls:
             function_name = tool_call.get("function", {}).get("name")
             function_args_str = tool_call.get("function", {}).get("arguments", "{}")
             
-            print(f"[M.A.D.] Calling tool: {function_name}")
-            print(f"[M.A.D.] Arguments: {function_args_str}")
+            olliePrint_simple(f"[M.A.D.] Calling tool: {function_name}", level='debug')
+            olliePrint_simple(f"[M.A.D.] Arguments: {function_args_str}", level='debug')
 
             try:
                 # The arguments are a JSON string, so we need to parse them
@@ -91,7 +91,7 @@ Analyze this turn: What new information about Ian or his interests should be sto
                 else:
                     result = {"success": False, "error": f"Unknown tool: {function_name}"}
                 
-                print(f"[M.A.D.] Tool Result: {result}")
+                olliePrint_simple(f"[M.A.D.] Tool Result: {result}", level='debug')
 
                 results.append({
                     "tool": function_name,
@@ -105,7 +105,7 @@ Analyze this turn: What new information about Ian or his interests should be sto
                     "args": function_args_str, # Log the raw string on failure
                     "result": {"success": False, "error": str(e)}
                 })
-        print("---------------------------\n")
+        olliePrint_simple("---------------------------", level='debug')
         
         return results
 
@@ -164,18 +164,18 @@ Analyze this turn: What new information about Ian or his interests should be sto
             raw_content = response_message.get('content', '')
             tool_calls = response_message.get('tool_calls', [])
 
-            print("\n--- M.A.D. Raw Response ---")
-            print(raw_content)
-            print("---------------------------\n")
+            olliePrint_simple("--- M.A.D. Raw Response ---", level='debug')
+            olliePrint_simple(raw_content, level='debug')
+            olliePrint_simple("---------------------------", level='debug')
             
             # Extract thinking and clean content
             thinking = self._extract_think_content(raw_content)
             clean_content = self._strip_think_tags(raw_content)
 
             if thinking:
-                print("\n--- M.A.D. Thinking ---")
-                print(thinking)
-                print("------------------------\n")
+                olliePrint_simple("--- M.A.D. Thinking ---", level='debug')
+                olliePrint_simple(thinking, level='debug')
+                olliePrint_simple("------------------------", level='debug')
             
             # Add to M.A.D.'s analysis history
             analysis_turn = f"USER: {user_message}\nFRED: {fred_response}"

--- a/agents/pivot.py
+++ b/agents/pivot.py
@@ -67,9 +67,9 @@ class PivotAgent:
                 }
             }]
 
-            print(f"\n--- P.I.V.O.T. Tool Call ---")
-            print(json.dumps(tool_call, indent=2))
-            print(f"----------------------------\n")
+            olliePrint_simple("--- P.I.V.O.T. Tool Call ---", level='debug')
+            olliePrint_simple(json.dumps(tool_call, indent=2), level='debug')
+            olliePrint_simple("----------------------------", level='debug')
             
             results = handle_tool_calls(tool_call)
             

--- a/agents/synapse.py
+++ b/agents/synapse.py
@@ -29,11 +29,12 @@ class SynapseAgent:
         Creates bullet points that read like F.R.E.D.'s fleeting thoughts.
         """
         try:
-            print(f"\n========== [{self.name}] INPUT ==========")
-            print(
-                json.dumps(agent_outputs, indent=2)[:1000]
+            olliePrint_simple(f"========== [{self.name}] INPUT ==========")
+            olliePrint_simple(
+                json.dumps(agent_outputs, indent=2)[:1000],
+                level='debug'
             )  # truncate to avoid huge log
-            print(f"========== [{self.name}] INPUT END =========\n")
+            olliePrint_simple(f"========== [{self.name}] INPUT END =========")
             olliePrint_simple(
                 f"[{self.name}] Synthesizing context from {len(agent_outputs)} agents..."
             )
@@ -42,9 +43,9 @@ class SynapseAgent:
                 agent_outputs, l2_summaries, user_query, visual_context
             )
 
-            print(f"========== [{self.name}] SYNTHESIS PROMPT ==========")
-            print(synthesis_prompt[:2000])
-            print("========== [{self.name}] SYNTHESIS PROMPT END =========\n")
+            olliePrint_simple(f"========== [{self.name}] SYNTHESIS PROMPT ==========")
+            olliePrint_simple(synthesis_prompt[:2000], level='debug')
+            olliePrint_simple(f"========== [{self.name}] SYNTHESIS PROMPT END =========")
             response = ollama_manager.chat_concurrent_safe(
                 model=config.SYNAPSE_OLLAMA_MODEL,
                 messages=[

--- a/memory/db_exports/dump_L2_db.py
+++ b/memory/db_exports/dump_L2_db.py
@@ -20,10 +20,16 @@ import sys
 from datetime import datetime
 from contextlib import closing
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir, os.pardir))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ollie_print import olliePrint_simple
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # The database lives one directory above this script (memory/L2_episodic_cache.db)
 DB_PATH = os.path.join(SCRIPT_DIR, "..", "L2_episodic_cache.db")
 
@@ -62,7 +68,7 @@ def main():
     with closing(duckdb.connect(DB_PATH)) as conn:
         tables = conn.execute("SHOW TABLES").fetchall()
         if not tables:
-            print("[dump_L2_db] No tables found in the database.")
+            olliePrint_simple("No tables found in the database.")
             return
 
         # Build a JSON-serialisable dict: {table_name: [row_dicts]}
@@ -73,11 +79,11 @@ def main():
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(db_dump, f, ensure_ascii=False, indent=2, default=str)
 
-    print(f"[dump_L2_db] Export complete → {out_path}")
+    olliePrint_simple(f"Export complete → {out_path}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as exc:
-        print(f"[dump_L2_db] Error: {exc}")
+        olliePrint_simple(f"Error: {exc}", level='error')

--- a/memory/db_exports/dump_L3_db.py
+++ b/memory/db_exports/dump_L3_db.py
@@ -20,10 +20,16 @@ import sys
 from datetime import datetime
 from contextlib import closing
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, os.pardir, os.pardir))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from ollie_print import olliePrint_simple
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # The L3 DB lives two directories up (memory/memory.db)
 DB_PATH = os.path.join(SCRIPT_DIR, "..", "memory.db")
 
@@ -60,7 +66,7 @@ def main():
     with closing(duckdb.connect(DB_PATH)) as conn:
         tables = conn.execute("SHOW TABLES").fetchall()
         if not tables:
-            print("[dump_L3_db] No tables found in the database.")
+            olliePrint_simple("No tables found in the database.")
             return
 
         db_dump: dict[str, list[dict]] = {}
@@ -70,11 +76,11 @@ def main():
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(db_dump, f, ensure_ascii=False, indent=2, default=str)
 
-    print(f"[dump_L3_db] Export complete → {out_path}")
+    olliePrint_simple(f"Export complete → {out_path}")
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as exc:
-        print(f"[dump_L3_db] Error: {exc}")
+        olliePrint_simple(f"Error: {exc}", level='error')

--- a/ollama_chat.py
+++ b/ollama_chat.py
@@ -49,12 +49,12 @@ def main():
                 messages=messages,
                 stream=True,
             )
-            
+
             for chunk in stream:
                 response_piece = chunk['message']['content']
-                sys.stdout.write(response_piece)
-                sys.stdout.flush()
                 full_response += response_piece
+
+            olliePrint_simple(full_response)
 
             messages.append({
                 'role': 'assistant',

--- a/ollama_manager.py
+++ b/ollama_manager.py
@@ -11,6 +11,17 @@ except ImportError:
         print(f"[{level.upper()}] {msg}")
 
     def log_model_io(model, inputs, outputs):
+        if isinstance(inputs, list):
+            for m in reversed(inputs):
+                if isinstance(m, dict) and m.get('role') == 'user':
+                    inputs = m.get('content', '')
+                    break
+        if isinstance(outputs, dict) and 'embedding' in outputs:
+            emb = outputs['embedding']
+            if isinstance(emb, (list, tuple)):
+                outputs = f"[{len(emb)}-dimensional embedding]"
+        elif isinstance(outputs, (list, tuple)) and all(isinstance(x, (int, float)) for x in outputs):
+            outputs = f"[{len(outputs)}-dimensional vector]"
         print(f"[MODEL {model} INPUT]: {inputs}")
         print(f"[MODEL {model} OUTPUT]: {outputs}")
 

--- a/scripts/trigger_sleep_cycle.py
+++ b/scripts/trigger_sleep_cycle.py
@@ -28,8 +28,9 @@ if PROJECT_ROOT not in sys.path:
 
 try:
     from Tools import tool_trigger_sleep_cycle  # noqa: E402
+    from ollie_print import olliePrint_simple  # noqa: E402
 except ImportError as exc:  # pragma: no cover
-    sys.stderr.write(f"[trigger_sleep_cycle] Failed to import Tools: {exc}\n")
+    sys.stderr.write(f"[trigger_sleep_cycle] Failed to import dependencies: {exc}\n")
     sys.exit(1)
 
 
@@ -40,13 +41,13 @@ def main() -> None:  # pragma: no cover
     result = tool_trigger_sleep_cycle()
 
     if not result.get("success", False):
-        sys.stderr.write(f"[trigger_sleep_cycle] Sleep cycle failed: {result.get('error')}\n")
+        olliePrint_simple(f"Sleep cycle failed: {result.get('error')}", level='error')
         sys.exit(1)
 
     # Pretty print summary
-    print("==== F.R.E.D. Sleep Cycle Summary ====")
-    print(result.get("summary", "<no summary provided>"))
-    print("======================================\n")
+    olliePrint_simple("==== F.R.E.D. Sleep Cycle Summary ====")
+    olliePrint_simple(result.get("summary", "<no summary provided>"))
+    olliePrint_simple("======================================\n")
 
     # ------------------------------------------------------------------
     # Determine output filename
@@ -65,9 +66,9 @@ def main() -> None:  # pragma: no cover
     try:
         with open(out_path, "w", encoding="utf-8") as fp:
             json.dump(result, fp, ensure_ascii=False, indent=2, default=str)
-        print(f"[trigger_sleep_cycle] Detailed report written to: {out_path}")
+        olliePrint_simple(f"Detailed report written to: {out_path}")
     except (IOError, OSError) as io_err:  # pragma: no cover
-        sys.stderr.write(f"[trigger_sleep_cycle] Failed to write report: {io_err}\n")
+        olliePrint_simple(f"Failed to write report: {io_err}", level='error')
 
 
 if __name__ == "__main__":

--- a/web_search_cli.py
+++ b/web_search_cli.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Any, Dict
 
 import config as cfg_module
+from ollie_print import olliePrint_simple
 
 # Configure logging
 logging.basicConfig(
@@ -102,20 +103,20 @@ def main() -> None:
         results = run_search(query)
         
         # Print summary
-        print("\n=== Gist Summary ===\n")
+        olliePrint_simple("=== Gist Summary ===")
         summary = results.get("summary", "No summary generated.")
-        print(summary)
-        
+        olliePrint_simple(summary)
+
         # Print top links with ranking
         links = results.get("links", [])
         if links:
-            print("\n=== Top Links ===\n")
+            olliePrint_simple("=== Top Links ===")
             for i, link in enumerate(links, 1):
                 title = link.get("title", "No title")
                 url = link.get("url", "")
                 score = link.get("score", link.get("relevance_score", 0))
-                print(f"{i}. {title} (Relevance: {score:.2f})")
-                print(f"   {url}\n")
+                olliePrint_simple(f"{i}. {title} (Relevance: {score:.2f})")
+                olliePrint_simple(f"   {url}")
         
         # Save results to file
         output_file = args.output or save_results_to_file(query, results)

--- a/web_search_core.py
+++ b/web_search_core.py
@@ -12,6 +12,7 @@ import trafilatura
 from datetime import datetime
 
 import config
+from ollie_print import olliePrint_simple
 from ollama_manager import OllamaConnectionManager
 from Tools import search_brave, search_searchapi  # Import existing search functions
 
@@ -84,7 +85,7 @@ def gather_links(query: str, max_results: int = 5) -> List[Dict[str, str]]:
         if brave_results and isinstance(brave_results, dict):
             _add_items(brave_results.get("web", []))
     except Exception as e:
-        print(f"Brave search failed: {e}")
+        olliePrint_simple(f"[WEB_SEARCH] Brave search failed: {e}", level='warning')
 
     # --- Fallback: SearchAPI --------------------------------------------------
     if len(all_results) < max_results:
@@ -93,7 +94,7 @@ def gather_links(query: str, max_results: int = 5) -> List[Dict[str, str]]:
             if searchapi_results and isinstance(searchapi_results, dict):
                 _add_items(searchapi_results.get("web", []))
         except Exception as e:
-            print(f"SearchAPI fallback failed: {e}")
+            olliePrint_simple(f"[WEB_SEARCH] SearchAPI fallback failed: {e}", level='warning')
 
     return all_results[:max_results]
 
@@ -149,7 +150,7 @@ def extract_page_content(url: str) -> Optional[Dict[str, str]]:
         return result
         
     except Exception as e:
-        print(f"Failed to extract content from {url}: {e}")
+        olliePrint_simple(f"[WEB_SEARCH] Failed to extract content from {url}: {e}", level='error')
         return None
 
 
@@ -195,7 +196,10 @@ def intelligent_search(query: str, search_priority: str = "quick", mode: str = "
                     'mode': mode
                 }
         except Exception as e:
-            print(f"[WARNING] Agenda enqueue failed: {e}; continuing with quick search fallback")
+            olliePrint_simple(
+                f"[WEB_SEARCH] Agenda enqueue failed: {e}; continuing with quick search fallback",
+                level='warning'
+            )
         # If enqueue fails, continue with quick search fallback
     
     try:
@@ -286,7 +290,7 @@ def intelligent_search(query: str, search_priority: str = "quick", mode: str = "
         }
         
     except Exception as e:
-        print(f"Intelligent search failed: {e}")
+        olliePrint_simple(f"[WEB_SEARCH] Intelligent search failed: {e}", level='error')
         return {
             'query': query,
             'links': [],
@@ -410,5 +414,5 @@ def calculate_relevance_score(query: str, title: str) -> float:
         return max(0.0, cosine_sim)
 
     except Exception as e:
-        print(f"Relevance calculation failed: {e}")
+        olliePrint_simple(f"[WEB_SEARCH] Relevance calculation failed: {e}", level='error')
         return 0.0


### PR DESCRIPTION
## Summary
- Collapse model IO logs to show only the latest user prompt and response, hiding raw embedding vectors
- Provide graceful fallback logging in `ollama_manager` to avoid dumping embeddings when color logger isn't available
- Use the Ollie color logger in auxiliary scripts like the sleep-cycle trigger and database dump tools for clean output

## Testing
- `pip install ollama`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68924d9d08408320a2c260defa95b319